### PR TITLE
DT-86 - Update Projected Turnout Model

### DIFF
--- a/prisma/migrations/20250602205144_new_projected_turnout/migration.sql
+++ b/prisma/migrations/20250602205144_new_projected_turnout/migration.sql
@@ -1,0 +1,35 @@
+/*
+  Warnings:
+
+  - You are about to drop the `projected_turnout` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Race" ADD COLUMN     "projected_turnout_id" UUID;
+
+-- DropTable
+DROP TABLE "projected_turnout";
+
+-- CreateTable
+CREATE TABLE "Projected_Turnout" (
+    "id" UUID NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "geoid" TEXT NOT NULL,
+    "state" TEXT NOT NULL,
+    "L2_office_type" TEXT NOT NULL,
+    "L2_office_name" TEXT NOT NULL,
+    "year" INTEGER NOT NULL,
+    "electionCode" "ElectionCode" NOT NULL,
+    "projected_turnout" INTEGER NOT NULL,
+    "inference_date" TIMESTAMP(3) NOT NULL,
+    "model_version" TEXT NOT NULL,
+
+    CONSTRAINT "Projected_Turnout_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Projected_Turnout_geoid_key" ON "Projected_Turnout"("geoid");
+
+-- AddForeignKey
+ALTER TABLE "Race" ADD CONSTRAINT "Race_projected_turnout_id_fkey" FOREIGN KEY ("projected_turnout_id") REFERENCES "Projected_Turnout"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20250603005329_lowercase_l2_columns/migration.sql
+++ b/prisma/migrations/20250603005329_lowercase_l2_columns/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `L2_office_name` on the `Projected_Turnout` table. All the data in the column will be lost.
+  - You are about to drop the column `L2_office_type` on the `Projected_Turnout` table. All the data in the column will be lost.
+  - Added the required column `l2_office_name` to the `Projected_Turnout` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `l2_office_type` to the `Projected_Turnout` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Projected_Turnout" DROP COLUMN "L2_office_name",
+DROP COLUMN "L2_office_type",
+ADD COLUMN     "l2_office_name" TEXT NOT NULL,
+ADD COLUMN     "l2_office_type" TEXT NOT NULL;

--- a/prisma/schema/projectedTurnout.prisma
+++ b/prisma/schema/projectedTurnout.prisma
@@ -16,8 +16,8 @@ model ProjectedTurnout {
   updatedAt        DateTime     @updatedAt @map("updated_at")
   geoid            String       @unique
   state            String
-  L2DistrictType   String       @map("L2_office_type") // Do we want these two from L2 for debugging / investigations?
-  L2DistrictName   String       @map("L2_office_name")
+  L2DistrictType   String       @map("l2_office_type") // Do we want these two from L2 for debugging / investigations?
+  L2DistrictName   String       @map("l2_office_name")
   year             Int
   electionCode     ElectionCode
   projectedTurnout Int          @map("projected_turnout")

--- a/prisma/schema/projectedTurnout.prisma
+++ b/prisma/schema/projectedTurnout.prisma
@@ -11,18 +11,20 @@ enum ElectionCode {
 }
 
 model ProjectedTurnout {
-  id              String       @id @db.Uuid
-  createdAt       DateTime     @default(now()) @map("created_at")
-  updatedAt       DateTime     @updatedAt @map("updated_at")
-  state           String
-  officeType      String       @map("office_type")
-  officeName      String       @map("office_name")
-  year            Int
-  electionCode    ElectionCode
-  turnoutEstimate Int?         @map("turnout_estimate")
-  inferenceDate   DateTime     @map("inference_date")
-  modelVersion    String?      @map("model_version")
+  id               String       @id @map("id") @db.Uuid
+  createdAt        DateTime     @default(now()) @map("created_at")
+  updatedAt        DateTime     @updatedAt @map("updated_at")
+  geoid            String       @unique
+  state            String
+  L2DistrictType   String       @map("L2_office_type") // Do we want these two from L2 for debugging / investigations?
+  L2DistrictName   String       @map("L2_office_name")
+  year             Int
+  electionCode     ElectionCode
+  projectedTurnout Int          @map("projected_turnout")
+  inferenceDate    DateTime     @map("inference_date")
+  modelVersion     String       @map("model_version")
 
-  @@unique([state, officeType, officeName, year, electionCode])
-  @@map("projected_turnout")
+  Races Race[]
+
+  @@map("Projected_Turnout")
 }

--- a/prisma/schema/race.prisma
+++ b/prisma/schema/race.prisma
@@ -41,9 +41,11 @@ model Race {
   frequency               Int[]         @map("frequency")
 
   // Relations
-  Place       Place?      @relation(fields: [placeId], references: [id])
-  placeId     String?     @map("place_id") @db.Uuid
-  Candidacies Candidacy[]
+  Place              Place?            @relation(fields: [placeId], references: [id])
+  placeId            String?           @map("place_id") @db.Uuid
+  Candidacies        Candidacy[]
+  projectedTurnoutId String?           @map("projected_turnout_id") @db.Uuid
+  ProjectedTurnout   ProjectedTurnout? @relation(fields: [projectedTurnoutId], references: [id])
 
   @@index([slug])
 }


### PR DESCRIPTION
This will drop the current projected turnout table, which should be fine since it's empty and unused