### PR TITLE
ENG-7589 - Add Position to Place relation, and some code for serving it

### DIFF
--- a/prisma/migrations/20260501180000_position_place_relation/migration.sql
+++ b/prisma/migrations/20260501180000_position_place_relation/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Position" ADD COLUMN     "place_id" UUID;
+
+-- CreateIndex
+CREATE INDEX "Position_place_id_idx" ON "Position"("place_id");
+
+-- AddForeignKey
+ALTER TABLE "Position" ADD CONSTRAINT "Position_place_id_fkey" FOREIGN KEY ("place_id") REFERENCES "Place"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema/place.prisma
+++ b/prisma/schema/place.prisma
@@ -19,7 +19,8 @@ model Place {
   homeValue             Int?    @map("home_value")
 
   // Relations
-  Races    Race[]
+  Races     Race[]
+  Positions Position[]
   // Recursive relationships
   children Place[] @relation("PlaceHierarchy")
   parent   Place?  @relation("PlaceHierarchy", fields: [parentId], references: [id])

--- a/prisma/schema/position.prisma
+++ b/prisma/schema/position.prisma
@@ -8,4 +8,8 @@ model Position {
     // Relations
     district   District? @relation(fields: [districtId], references: [id])
     districtId String?   @map("district_id") @db.Uuid()
+    place      Place?    @relation(fields: [placeId], references: [id])
+    placeId    String?   @map("place_id") @db.Uuid()
+
+    @@index([placeId])
 }

--- a/src/places/places.controller.ts
+++ b/src/places/places.controller.ts
@@ -1,5 +1,9 @@
-import { Controller, Get, Query } from '@nestjs/common'
-import { MostElectionsDto, PlaceFilterDto } from './places.schema'
+import { Controller, Get, Param, Query } from '@nestjs/common'
+import {
+  GetPlaceByPositionIdParamsDTO,
+  MostElectionsDto,
+  PlaceFilterDto,
+} from './places.schema'
 import { PlacesService } from './places.service'
 
 const MIN_RACES = 100
@@ -11,6 +15,13 @@ export class PlaceController {
   @Get()
   async getPlaces(@Query() filterDto: PlaceFilterDto) {
     return this.placesService.getPlaces(filterDto)
+  }
+
+  @Get('by-position-id/:positionId')
+  async getPlaceByPositionId(
+    @Param() params: GetPlaceByPositionIdParamsDTO,
+  ) {
+    return this.placesService.getPlaceByPositionId(params.positionId)
   }
 
   @Get('most-elections')

--- a/src/places/places.schema.ts
+++ b/src/places/places.schema.ts
@@ -79,6 +79,14 @@ const placeFilterSchema = z.object({
 })
 ///  .strict()
 
+export const getPlaceByPositionIdParamsSchema = z.object({
+  positionId: z.string().uuid('Position ID must be a valid UUID'),
+})
+
+export class GetPlaceByPositionIdParamsDTO extends createZodDto(
+  getPlaceByPositionIdParamsSchema,
+) {}
+
 const mostElectionsSchema = z.object({
   count: z
     .string()

--- a/src/places/places.service.test.ts
+++ b/src/places/places.service.test.ts
@@ -1,0 +1,63 @@
+import { NotFoundException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PlacesService } from './places.service'
+
+describe('PlacesService', () => {
+  let service: PlacesService
+  let findUnique: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    findUnique = vi.fn()
+    service = new PlacesService()
+    Object.defineProperty(service, '_prisma', {
+      value: {
+        position: {
+          findUnique,
+        },
+      },
+    })
+  })
+
+  it('returns place when position has an associated place', async () => {
+    const place = {
+      id: 'place-1',
+      name: 'Cornelius',
+      slug: 'or/washington/cornelius',
+      state: 'OR',
+    }
+    findUnique.mockResolvedValue({ place })
+
+    const positionId = 'a0000000-0000-0000-0000-000000000001'
+    const result = await service.getPlaceByPositionId(positionId)
+
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { id: positionId },
+      select: { place: true },
+    })
+    expect(result).toEqual(place)
+  })
+
+  it('throws not found when position does not exist', async () => {
+    findUnique.mockResolvedValue(null)
+
+    await expect(
+      service.getPlaceByPositionId('00000000-0000-0000-0000-000000000099'),
+    ).rejects.toThrow(
+      new NotFoundException(
+        'Position not found for id=00000000-0000-0000-0000-000000000099',
+      ),
+    )
+  })
+
+  it('throws not found when position has no associated place', async () => {
+    findUnique.mockResolvedValue({ place: null })
+
+    await expect(
+      service.getPlaceByPositionId('00000000-0000-0000-0000-000000000001'),
+    ).rejects.toThrow(
+      new NotFoundException(
+        'No place associated with position id=00000000-0000-0000-0000-000000000001',
+      ),
+    )
+  })
+})

--- a/src/places/places.service.ts
+++ b/src/places/places.service.ts
@@ -121,6 +121,22 @@ export class PlacesService extends createPrismaBase(MODELS.Place) {
     return places
   }
 
+  async getPlaceByPositionId(positionId: string) {
+    const result = await this.client.position.findUnique({
+      where: { id: positionId },
+      select: { place: true },
+    })
+    if (!result) {
+      throw new NotFoundException(`Position not found for id=${positionId}`)
+    }
+    if (!result.place) {
+      throw new NotFoundException(
+        `No place associated with position id=${positionId}`,
+      )
+    }
+    return result.place
+  }
+
   async getPlacesWithMostElections(minRaces: number, count: number) {
     const places = await this.client.$queryRaw<
       { slug: string; name: string; race_count: number }[]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new DB foreign-key relationship and index between `Position` and `Place`, plus a new API path that depends on that data being populated; mismatched/missing backfills could surface as new 404s.
> 
> **Overview**
> Adds an optional `Position.place_id` foreign key to `Place` (with an index) and updates the Prisma schema to model the bidirectional `Place`↔`Position` relationship.
> 
> Exposes `GET /places/by-position-id/:positionId`, validating the UUID param and returning the related place via `PlacesService.getPlaceByPositionId`; returns `NotFoundException` if the position is missing or has no associated place (covered by new unit tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 982fa28e7b812f5dd12273d8f098a1588ab4cd47. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->