### PR TITLE
feat(voter-issues): add /voter-issues endpoint backed by DistrictTopIssue

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { CandidaciesModule } from './candidacies/candidacies.module'
 import { ProjectedTurnoutModule } from './projectedTurnout/projectedTurnout.module'
 import { DistrictsModule } from './districts/districts.module'
 import { PositionsModule } from './positions/positions.module'
+import { VoterIssuesModule } from './voterIssues/voterIssues.module'
 import { loggerModule } from './observability/logging/logger-module'
 
 @Module({
@@ -18,6 +19,7 @@ import { loggerModule } from './observability/logging/logger-module'
     ProjectedTurnoutModule,
     DistrictsModule,
     PositionsModule,
+    VoterIssuesModule,
   ],
 })
 export class AppModule {}

--- a/src/voterIssues/voterIssues.controller.test.ts
+++ b/src/voterIssues/voterIssues.controller.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { VoterIssuesController } from './voterIssues.controller'
+import { VoterIssuesService } from './voterIssues.service'
+
+describe('VoterIssuesController', () => {
+  let controller: VoterIssuesController
+  let getVoterIssues: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    getVoterIssues = vi.fn()
+    controller = new VoterIssuesController({
+      getVoterIssues,
+    } as unknown as VoterIssuesService)
+  })
+
+  it('forwards districtId and limit to the service and returns the result', async () => {
+    const issues = [
+      { label: 'Education', score: 88, priority: 'high' as const },
+    ]
+    getVoterIssues.mockResolvedValue(issues)
+
+    const result = await controller.getVoterIssues({
+      districtId: 'd-1',
+      limit: 10,
+    })
+
+    expect(getVoterIssues).toHaveBeenCalledWith({
+      districtId: 'd-1',
+      limit: 10,
+    })
+    expect(result).toEqual(issues)
+  })
+})

--- a/src/voterIssues/voterIssues.controller.ts
+++ b/src/voterIssues/voterIssues.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Query } from '@nestjs/common'
+import { VoterIssuesService } from './voterIssues.service'
+import { GetVoterIssuesQueryDTO, VoterIssue } from './voterIssues.schema'
+
+@Controller('voter-issues')
+export class VoterIssuesController {
+  constructor(private readonly voterIssues: VoterIssuesService) {}
+
+  @Get()
+  async getVoterIssues(
+    @Query() query: GetVoterIssuesQueryDTO,
+  ): Promise<VoterIssue[]> {
+    return this.voterIssues.getVoterIssues({
+      districtId: query.districtId,
+      ballotReadyPositionId: query.ballotReadyPositionId,
+      state: query.state,
+      city: query.city,
+      limit: query.limit,
+    })
+  }
+}

--- a/src/voterIssues/voterIssues.controller.ts
+++ b/src/voterIssues/voterIssues.controller.ts
@@ -12,9 +12,6 @@ export class VoterIssuesController {
   ): Promise<VoterIssue[]> {
     return this.voterIssues.getVoterIssues({
       districtId: query.districtId,
-      ballotReadyPositionId: query.ballotReadyPositionId,
-      state: query.state,
-      city: query.city,
       limit: query.limit,
     })
   }

--- a/src/voterIssues/voterIssues.module.ts
+++ b/src/voterIssues/voterIssues.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common'
+import { VoterIssuesController } from './voterIssues.controller'
+import { VoterIssuesService } from './voterIssues.service'
+
+@Module({
+  controllers: [VoterIssuesController],
+  providers: [VoterIssuesService],
+})
+export class VoterIssuesModule {}

--- a/src/voterIssues/voterIssues.schema.ts
+++ b/src/voterIssues/voterIssues.schema.ts
@@ -1,17 +1,10 @@
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 
-const getVoterIssuesQuerySchema = z
-  .object({
-    districtId: z.string().uuid().optional(),
-    ballotReadyPositionId: z.string().min(1).optional(),
-    state: z.string().length(2).optional(),
-    city: z.string().min(1).optional(),
-    limit: z.coerce.number().int().positive().max(50).optional().default(10),
-  })
-  .refine((v) => Boolean(v.districtId || v.ballotReadyPositionId), {
-    message: 'At least one of districtId or ballotReadyPositionId is required',
-  })
+const getVoterIssuesQuerySchema = z.object({
+  districtId: z.string().uuid(),
+  limit: z.coerce.number().int().positive().max(50).optional().default(10),
+})
 
 export class GetVoterIssuesQueryDTO extends createZodDto(
   getVoterIssuesQuerySchema,

--- a/src/voterIssues/voterIssues.schema.ts
+++ b/src/voterIssues/voterIssues.schema.ts
@@ -9,14 +9,9 @@ const getVoterIssuesQuerySchema = z
     city: z.string().min(1).optional(),
     limit: z.coerce.number().int().positive().max(50).optional().default(10),
   })
-  .refine(
-    (v) =>
-      Boolean(v.districtId || v.ballotReadyPositionId || v.state || v.city),
-    {
-      message:
-        'At least one of districtId, ballotReadyPositionId, state, or city is required',
-    },
-  )
+  .refine((v) => Boolean(v.districtId || v.ballotReadyPositionId), {
+    message: 'At least one of districtId or ballotReadyPositionId is required',
+  })
 
 export class GetVoterIssuesQueryDTO extends createZodDto(
   getVoterIssuesQuerySchema,

--- a/src/voterIssues/voterIssues.schema.ts
+++ b/src/voterIssues/voterIssues.schema.ts
@@ -1,0 +1,29 @@
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+const getVoterIssuesQuerySchema = z
+  .object({
+    districtId: z.string().uuid().optional(),
+    ballotReadyPositionId: z.string().min(1).optional(),
+    state: z.string().length(2).optional(),
+    city: z.string().min(1).optional(),
+    limit: z.coerce.number().int().positive().max(50).optional().default(10),
+  })
+  .refine(
+    (v) =>
+      Boolean(v.districtId || v.ballotReadyPositionId || v.state || v.city),
+    {
+      message:
+        'At least one of districtId, ballotReadyPositionId, state, or city is required',
+    },
+  )
+
+export class GetVoterIssuesQueryDTO extends createZodDto(
+  getVoterIssuesQuerySchema,
+) {}
+
+export type VoterIssue = {
+  label: string
+  score: number
+  priority: 'high' | 'medium' | 'low'
+}

--- a/src/voterIssues/voterIssues.service.test.ts
+++ b/src/voterIssues/voterIssues.service.test.ts
@@ -1,0 +1,130 @@
+import { NotFoundException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { VoterIssuesService } from './voterIssues.service'
+
+describe('VoterIssuesService', () => {
+  let service: VoterIssuesService
+  let findMany: ReturnType<typeof vi.fn>
+  let positionFindUnique: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    findMany = vi.fn()
+    positionFindUnique = vi.fn()
+    service = new VoterIssuesService()
+    Object.defineProperty(service, '_prisma', {
+      value: {
+        districtTopIssue: { findMany },
+        position: { findUnique: positionFindUnique },
+      },
+    })
+  })
+
+  describe('priorityForRank (via getVoterIssues mapping)', () => {
+    it('buckets ranks 1-3 as high, 4-6 as medium, >=7 as low', async () => {
+      findMany.mockResolvedValue([
+        { issueLabel: 'A', score: 90, issueRank: 1 },
+        { issueLabel: 'B', score: 80, issueRank: 3 },
+        { issueLabel: 'C', score: 70, issueRank: 4 },
+        { issueLabel: 'D', score: 60, issueRank: 6 },
+        { issueLabel: 'E', score: 50, issueRank: 7 },
+      ])
+
+      const result = await service.getVoterIssues({
+        districtId: 'd-1',
+        limit: 10,
+      })
+
+      expect(result.map((r) => r.priority)).toEqual([
+        'high',
+        'high',
+        'medium',
+        'medium',
+        'low',
+      ])
+    })
+  })
+
+  describe('getVoterIssues with districtId', () => {
+    it('queries DistrictTopIssue with the given districtId, ordered by issueRank, capped by limit', async () => {
+      findMany.mockResolvedValue([
+        { issueLabel: 'Education', score: 88, issueRank: 1 },
+      ])
+
+      const result = await service.getVoterIssues({
+        districtId: 'd-1',
+        limit: 5,
+      })
+
+      expect(findMany).toHaveBeenCalledWith({
+        where: { districtId: 'd-1' },
+        orderBy: { issueRank: 'asc' },
+        take: 5,
+        select: { issueLabel: true, score: true, issueRank: true },
+      })
+      expect(result).toEqual([
+        { label: 'Education', score: 88, priority: 'high' },
+      ])
+      expect(positionFindUnique).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getVoterIssues with ballotReadyPositionId', () => {
+    it('resolves district via position lookup', async () => {
+      positionFindUnique.mockResolvedValue({ districtId: 'd-2' })
+      findMany.mockResolvedValue([])
+
+      await service.getVoterIssues({
+        ballotReadyPositionId: 'br-pos-1',
+        limit: 10,
+      })
+
+      expect(positionFindUnique).toHaveBeenCalledWith({
+        where: { brPositionId: 'br-pos-1' },
+        select: { districtId: true },
+      })
+      expect(findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { districtId: 'd-2' } }),
+      )
+    })
+
+    it('throws NotFoundException when position is missing', async () => {
+      positionFindUnique.mockResolvedValue(null)
+
+      await expect(
+        service.getVoterIssues({
+          ballotReadyPositionId: 'missing',
+          limit: 10,
+        }),
+      ).rejects.toThrow(
+        new NotFoundException(`Position not found for brPositionId=missing`),
+      )
+      expect(findMany).not.toHaveBeenCalled()
+    })
+
+    it('throws NotFoundException when position has null districtId', async () => {
+      positionFindUnique.mockResolvedValue({ districtId: null })
+
+      await expect(
+        service.getVoterIssues({
+          ballotReadyPositionId: 'br-pos-1',
+          limit: 10,
+        }),
+      ).rejects.toThrow(
+        new NotFoundException(
+          `Position with brPositionId=br-pos-1 has no associated district`,
+        ),
+      )
+      expect(findMany).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getVoterIssues with no resolvable district', () => {
+    it('returns [] when neither districtId nor ballotReadyPositionId is provided', async () => {
+      const result = await service.getVoterIssues({ limit: 10 })
+
+      expect(result).toEqual([])
+      expect(findMany).not.toHaveBeenCalled()
+      expect(positionFindUnique).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/voterIssues/voterIssues.service.test.ts
+++ b/src/voterIssues/voterIssues.service.test.ts
@@ -1,130 +1,95 @@
-import { NotFoundException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { VoterIssuesService } from './voterIssues.service'
 
 describe('VoterIssuesService', () => {
   let service: VoterIssuesService
   let findMany: ReturnType<typeof vi.fn>
-  let positionFindUnique: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     findMany = vi.fn()
-    positionFindUnique = vi.fn()
     service = new VoterIssuesService()
     Object.defineProperty(service, '_prisma', {
       value: {
         districtTopIssue: { findMany },
-        position: { findUnique: positionFindUnique },
       },
     })
   })
 
-  describe('priorityForRank (via getVoterIssues mapping)', () => {
-    it('buckets ranks 1-3 as high, 4-6 as medium, >=7 as low', async () => {
-      findMany.mockResolvedValue([
-        { issueLabel: 'A', score: 90, issueRank: 1 },
-        { issueLabel: 'B', score: 80, issueRank: 3 },
-        { issueLabel: 'C', score: 70, issueRank: 4 },
-        { issueLabel: 'D', score: 60, issueRank: 6 },
-        { issueLabel: 'E', score: 50, issueRank: 7 },
-      ])
+  it('queries DistrictTopIssue with the given districtId, ordered by issueRank, capped by limit', async () => {
+    findMany.mockResolvedValue([
+      { issueLabel: 'Education', score: 88, issueRank: 1 },
+    ])
 
-      const result = await service.getVoterIssues({
-        districtId: 'd-1',
-        limit: 10,
-      })
-
-      expect(result.map((r) => r.priority)).toEqual([
-        'high',
-        'high',
-        'medium',
-        'medium',
-        'low',
-      ])
+    const result = await service.getVoterIssues({
+      districtId: 'd-1',
+      limit: 5,
     })
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: { districtId: 'd-1' },
+      orderBy: { issueRank: 'asc' },
+      take: 5,
+      select: { issueLabel: true, score: true, issueRank: true },
+    })
+    expect(result).toEqual([
+      { label: 'Education', score: 88, priority: 'high' },
+    ])
   })
 
-  describe('getVoterIssues with districtId', () => {
-    it('queries DistrictTopIssue with the given districtId, ordered by issueRank, capped by limit', async () => {
-      findMany.mockResolvedValue([
-        { issueLabel: 'Education', score: 88, issueRank: 1 },
-      ])
+  it('maps issueLabel to label and assigns priority by rank boundary', async () => {
+    findMany.mockResolvedValue([
+      { issueLabel: 'A', score: 90, issueRank: 1 },
+      { issueLabel: 'B', score: 80, issueRank: 3 },
+      { issueLabel: 'C', score: 70, issueRank: 4 },
+      { issueLabel: 'D', score: 60, issueRank: 6 },
+      { issueLabel: 'E', score: 50, issueRank: 7 },
+    ])
 
-      const result = await service.getVoterIssues({
-        districtId: 'd-1',
-        limit: 5,
-      })
-
-      expect(findMany).toHaveBeenCalledWith({
-        where: { districtId: 'd-1' },
-        orderBy: { issueRank: 'asc' },
-        take: 5,
-        select: { issueLabel: true, score: true, issueRank: true },
-      })
-      expect(result).toEqual([
-        { label: 'Education', score: 88, priority: 'high' },
-      ])
-      expect(positionFindUnique).not.toHaveBeenCalled()
+    const result = await service.getVoterIssues({
+      districtId: 'd-1',
+      limit: 10,
     })
+
+    expect(result).toEqual([
+      { label: 'A', score: 90, priority: 'high' },
+      { label: 'B', score: 80, priority: 'high' },
+      { label: 'C', score: 70, priority: 'medium' },
+      { label: 'D', score: 60, priority: 'medium' },
+      { label: 'E', score: 50, priority: 'low' },
+    ])
   })
 
-  describe('getVoterIssues with ballotReadyPositionId', () => {
-    it('resolves district via position lookup', async () => {
-      positionFindUnique.mockResolvedValue({ districtId: 'd-2' })
-      findMany.mockResolvedValue([])
+  it('returns an empty array when no rows are found', async () => {
+    findMany.mockResolvedValue([])
 
-      await service.getVoterIssues({
-        ballotReadyPositionId: 'br-pos-1',
-        limit: 10,
-      })
-
-      expect(positionFindUnique).toHaveBeenCalledWith({
-        where: { brPositionId: 'br-pos-1' },
-        select: { districtId: true },
-      })
-      expect(findMany).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { districtId: 'd-2' } }),
-      )
+    const result = await service.getVoterIssues({
+      districtId: 'd-empty',
+      limit: 10,
     })
 
-    it('throws NotFoundException when position is missing', async () => {
-      positionFindUnique.mockResolvedValue(null)
-
-      await expect(
-        service.getVoterIssues({
-          ballotReadyPositionId: 'missing',
-          limit: 10,
-        }),
-      ).rejects.toThrow(
-        new NotFoundException(`Position not found for brPositionId=missing`),
-      )
-      expect(findMany).not.toHaveBeenCalled()
-    })
-
-    it('throws NotFoundException when position has null districtId', async () => {
-      positionFindUnique.mockResolvedValue({ districtId: null })
-
-      await expect(
-        service.getVoterIssues({
-          ballotReadyPositionId: 'br-pos-1',
-          limit: 10,
-        }),
-      ).rejects.toThrow(
-        new NotFoundException(
-          `Position with brPositionId=br-pos-1 has no associated district`,
-        ),
-      )
-      expect(findMany).not.toHaveBeenCalled()
-    })
+    expect(result).toEqual([])
   })
 
-  describe('getVoterIssues with no resolvable district', () => {
-    it('returns [] when neither districtId nor ballotReadyPositionId is provided', async () => {
-      const result = await service.getVoterIssues({ limit: 10 })
+  it('forwards a custom limit to take', async () => {
+    findMany.mockResolvedValue([])
 
-      expect(result).toEqual([])
-      expect(findMany).not.toHaveBeenCalled()
-      expect(positionFindUnique).not.toHaveBeenCalled()
+    await service.getVoterIssues({ districtId: 'd-1', limit: 25 })
+
+    expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 25 }))
+  })
+
+  it('preserves DB order (issueRank asc) in the output', async () => {
+    findMany.mockResolvedValue([
+      { issueLabel: 'First', score: 95, issueRank: 1 },
+      { issueLabel: 'Second', score: 70, issueRank: 2 },
+      { issueLabel: 'Third', score: 40, issueRank: 5 },
+    ])
+
+    const result = await service.getVoterIssues({
+      districtId: 'd-1',
+      limit: 10,
     })
+
+    expect(result.map((r) => r.label)).toEqual(['First', 'Second', 'Third'])
   })
 })

--- a/src/voterIssues/voterIssues.service.ts
+++ b/src/voterIssues/voterIssues.service.ts
@@ -1,11 +1,6 @@
-import { Injectable, NotFoundException } from '@nestjs/common'
+import { Injectable } from '@nestjs/common'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { VoterIssue } from './voterIssues.schema'
-
-type ResolveDistrictParams = {
-  districtId?: string
-  ballotReadyPositionId?: string
-}
 
 @Injectable()
 export class VoterIssuesService extends createPrismaBase(
@@ -16,20 +11,11 @@ export class VoterIssuesService extends createPrismaBase(
   }
 
   async getVoterIssues(params: {
-    districtId?: string
-    ballotReadyPositionId?: string
-    state?: string
-    city?: string
+    districtId: string
     limit: number
   }): Promise<VoterIssue[]> {
-    const districtId = await this.resolveDistrictId({
-      districtId: params.districtId,
-      ballotReadyPositionId: params.ballotReadyPositionId,
-    })
-    if (!districtId) return []
-
     const rows = await this.model.findMany({
-      where: { districtId },
+      where: { districtId: params.districtId },
       orderBy: { issueRank: 'asc' },
       take: params.limit,
       select: { issueLabel: true, score: true, issueRank: true },
@@ -46,31 +32,5 @@ export class VoterIssuesService extends createPrismaBase(
     if (rank <= 3) return 'high'
     if (rank <= 6) return 'medium'
     return 'low'
-  }
-
-  private async resolveDistrictId(
-    params: ResolveDistrictParams,
-  ): Promise<string | null> {
-    if (params.districtId) return params.districtId
-
-    if (params.ballotReadyPositionId) {
-      const position = await this.client.position.findUnique({
-        where: { brPositionId: params.ballotReadyPositionId },
-        select: { districtId: true },
-      })
-      if (!position) {
-        throw new NotFoundException(
-          `Position not found for brPositionId=${params.ballotReadyPositionId}`,
-        )
-      }
-      if (!position.districtId) {
-        throw new NotFoundException(
-          `Position with brPositionId=${params.ballotReadyPositionId} has no associated district`,
-        )
-      }
-      return position.districtId
-    }
-
-    return null
   }
 }

--- a/src/voterIssues/voterIssues.service.ts
+++ b/src/voterIssues/voterIssues.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, NotFoundException } from '@nestjs/common'
+import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
+import { VoterIssue } from './voterIssues.schema'
+
+type ResolveDistrictParams = {
+  districtId?: string
+  ballotReadyPositionId?: string
+}
+
+@Injectable()
+export class VoterIssuesService extends createPrismaBase(
+  MODELS.DistrictTopIssue,
+) {
+  constructor() {
+    super()
+  }
+
+  async getVoterIssues(params: {
+    districtId?: string
+    ballotReadyPositionId?: string
+    state?: string
+    city?: string
+    limit: number
+  }): Promise<VoterIssue[]> {
+    const districtId = await this.resolveDistrictId({
+      districtId: params.districtId,
+      ballotReadyPositionId: params.ballotReadyPositionId,
+    })
+    if (!districtId) return []
+
+    const rows = await this.model.findMany({
+      where: { districtId },
+      orderBy: { issueRank: 'asc' },
+      take: params.limit,
+      select: { issueLabel: true, score: true, issueRank: true },
+    })
+
+    return rows.map((row) => ({
+      label: row.issueLabel,
+      score: row.score,
+      priority: this.priorityForRank(row.issueRank),
+    }))
+  }
+
+  private priorityForRank(rank: number): VoterIssue['priority'] {
+    if (rank <= 3) return 'high'
+    if (rank <= 6) return 'medium'
+    return 'low'
+  }
+
+  private async resolveDistrictId(
+    params: ResolveDistrictParams,
+  ): Promise<string | null> {
+    if (params.districtId) return params.districtId
+
+    if (params.ballotReadyPositionId) {
+      const position = await this.client.position.findUnique({
+        where: { brPositionId: params.ballotReadyPositionId },
+        select: { districtId: true },
+      })
+      if (!position) {
+        throw new NotFoundException(
+          `Position not found for brPositionId=${params.ballotReadyPositionId}`,
+        )
+      }
+      return position.districtId
+    }
+
+    return null
+  }
+}

--- a/src/voterIssues/voterIssues.service.ts
+++ b/src/voterIssues/voterIssues.service.ts
@@ -63,6 +63,11 @@ export class VoterIssuesService extends createPrismaBase(
           `Position not found for brPositionId=${params.ballotReadyPositionId}`,
         )
       }
+      if (!position.districtId) {
+        throw new NotFoundException(
+          `Position with brPositionId=${params.ballotReadyPositionId} has no associated district`,
+        )
+      }
       return position.districtId
     }
 


### PR DESCRIPTION
## Why

Pairs with [gp-api#1555](https://github.com/thegoodparty/gp-api/pull/1555). gp-api / gp-webapp need a way to read the top Haystaq issues per district that PR #147 added to the `DistrictTopIssue` table.

## What

Adds `GET /voter-issues` and a new `VoterIssuesModule`.

**Query params** (at least one of `districtId` or `ballotReadyPositionId` required to return data):
- `districtId` (UUID) — direct lookup
- `ballotReadyPositionId` (string) — resolved via `Position.brPositionId` → `Position.districtId`
- `state`, `city` — accepted (forwarded by gp-api) but currently unused; `DistrictTopIssue` is keyed by district, not place
- `limit` (1–50, default 10)

**Response:** `VoterIssue[]` where `VoterIssue = { label: string, score: number, priority: 'high' | 'medium' | 'low' }`.

**Resolution:** rows ordered by `issueRank` ascending. Priority bucketed by rank (1–3 → `high`, 4–6 → `medium`, else `low`).

## Files

- `src/voterIssues/voterIssues.module.ts` (new)
- `src/voterIssues/voterIssues.controller.ts` (new)
- `src/voterIssues/voterIssues.service.ts` (new) — extends `createPrismaBase(MODELS.DistrictTopIssue)`
- `src/voterIssues/voterIssues.schema.ts` (new)
- `src/app.module.ts` — register `VoterIssuesModule`

## Notes

- No schema or migration changes — uses `DistrictTopIssue` as added in #147.
- No tests added yet; happy to mirror `positions.service.test.ts` if reviewers want.
- Priority cutoffs are an opinionated default. If you'd prefer score-based bucketing (e.g. ≥70 high, ≥40 medium) say so and I'll change it before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public API endpoint that queries the database and introduces new validation/error behavior (including `NotFoundException` for unknown `ballotReadyPositionId`). Risk is moderate due to new request surface area and potential mismatches between accepted query params (e.g. `state`/`city`) and actual filtering logic.
> 
> **Overview**
> Adds a new `VoterIssuesModule` and `GET /voter-issues` endpoint to return top voter issues for a resolved district.
> 
> The endpoint validates query params via Zod (optional `districtId`, `ballotReadyPositionId`, `state`, `city`, and `limit` with a default of 10), resolves `districtId` directly or via `Position.brPositionId`, then reads `DistrictTopIssue` ordered by `issueRank` and returns `{ label, score, priority }` with priority bucketed by rank.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30fe83ef2ef3302a0cb98c056e36c691032c3649. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->