### PR TITLE
QA <- Dev

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { ProjectedTurnoutModule } from './projectedTurnout/projectedTurnout.modu
 import { DistrictsModule } from './districts/districts.module'
 import { PositionsModule } from './positions/positions.module'
 import { VoterIssuesModule } from './voterIssues/voterIssues.module'
+import { ZipToPositionModule } from './zipToPosition/zipToPosition.module'
 import { loggerModule } from './observability/logging/logger-module'
 
 @Module({
@@ -20,6 +21,7 @@ import { loggerModule } from './observability/logging/logger-module'
     DistrictsModule,
     PositionsModule,
     VoterIssuesModule,
+    ZipToPositionModule,
   ],
 })
 export class AppModule {}

--- a/src/zipToPosition/zipToPosition.controller.ts
+++ b/src/zipToPosition/zipToPosition.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Query } from '@nestjs/common'
+import { GetPositionsByZipQueryDTO } from './zipToPosition.schema'
+import { ZipToPositionService } from './zipToPosition.service'
+import { RaceListItem } from './zipToPosition.types'
+
+@Controller('positions')
+export class ZipToPositionController {
+  constructor(private readonly zipToPosition: ZipToPositionService) {}
+
+  @Get('by-zip')
+  async byZip(
+    @Query() query: GetPositionsByZipQueryDTO,
+  ): Promise<RaceListItem[]> {
+    return this.zipToPosition.findByZip({
+      zip: query.zip,
+      displayOfficeLevels: query.displayOfficeLevels,
+      electionDateFrom: query.electionDateFrom,
+      electionDateTo: query.electionDateTo,
+    })
+  }
+}

--- a/src/zipToPosition/zipToPosition.controller.ts
+++ b/src/zipToPosition/zipToPosition.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Query } from '@nestjs/common'
-import { GetPositionsByZipQueryDTO } from './zipToPosition.schema'
+import { SearchPositionsQueryDTO } from './zipToPosition.schema'
 import { ZipToPositionService } from './zipToPosition.service'
 import { RaceListItem } from './zipToPosition.types'
 
@@ -7,12 +7,14 @@ import { RaceListItem } from './zipToPosition.types'
 export class ZipToPositionController {
   constructor(private readonly zipToPosition: ZipToPositionService) {}
 
-  @Get('by-zip')
-  async byZip(
-    @Query() query: GetPositionsByZipQueryDTO,
+  @Get('search')
+  async search(
+    @Query() query: SearchPositionsQueryDTO,
   ): Promise<RaceListItem[]> {
-    return this.zipToPosition.findByZip({
+    return this.zipToPosition.search({
       zip: query.zip,
+      name: query.name,
+      officeType: query.officeType,
       displayOfficeLevels: query.displayOfficeLevels,
       electionDateFrom: query.electionDateFrom,
       electionDateTo: query.electionDateTo,

--- a/src/zipToPosition/zipToPosition.module.ts
+++ b/src/zipToPosition/zipToPosition.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common'
+import { ZipToPositionController } from './zipToPosition.controller'
+import { ZipToPositionService } from './zipToPosition.service'
+
+@Module({
+  controllers: [ZipToPositionController],
+  providers: [ZipToPositionService],
+})
+export class ZipToPositionModule {}

--- a/src/zipToPosition/zipToPosition.schema.ts
+++ b/src/zipToPosition/zipToPosition.schema.ts
@@ -1,4 +1,3 @@
-// election-api/src/zipToPosition/zipToPosition.schema.ts
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 

--- a/src/zipToPosition/zipToPosition.schema.ts
+++ b/src/zipToPosition/zipToPosition.schema.ts
@@ -12,21 +12,47 @@ const DISPLAY_OFFICE_LEVELS = [
   'Township',
 ] as const
 
-export const GetPositionsByZipQuerySchema = z.object({
-  zip: z.string().regex(/^\d{5}$/, 'zip must be 5 digits'),
-  displayOfficeLevels: z
-    .union([
-      z.enum(DISPLAY_OFFICE_LEVELS),
-      z.array(z.enum(DISPLAY_OFFICE_LEVELS)),
-    ])
+const OFFICE_TYPES = [
+  'Attorney',
+  'City Council',
+  'Clerk/Treasurer',
+  'Congressional',
+  'County Supervisor',
+  'Judge',
+  'Mayor',
+  'Other',
+  'School Board',
+  'Sheriff',
+  'State House',
+  'State Senate',
+  'Statewide/Governor',
+  'Town Council',
+] as const
+
+const arrayOrSingle = <T extends z.ZodTypeAny>(inner: T) =>
+  z
+    .union([inner, z.array(inner)])
     .optional()
     .transform((v) =>
       v === undefined ? undefined : Array.isArray(v) ? v : [v],
-    ),
-  electionDateFrom: z.string().date().optional(),
-  electionDateTo: z.string().date().optional(),
-})
+    )
 
-export class GetPositionsByZipQueryDTO extends createZodDto(
-  GetPositionsByZipQuerySchema,
+export const SearchPositionsQuerySchema = z
+  .object({
+    zip: z
+      .string()
+      .regex(/^\d{5}$/, 'zip must be 5 digits')
+      .optional(),
+    name: z.string().min(1).optional(),
+    officeType: arrayOrSingle(z.enum(OFFICE_TYPES)),
+    displayOfficeLevels: arrayOrSingle(z.enum(DISPLAY_OFFICE_LEVELS)),
+    electionDateFrom: z.string().date().optional(),
+    electionDateTo: z.string().date().optional(),
+  })
+  .refine((q) => q.zip || q.name || (q.officeType && q.officeType.length > 0), {
+    message: 'At least one of zip, name, or officeType is required',
+  })
+
+export class SearchPositionsQueryDTO extends createZodDto(
+  SearchPositionsQuerySchema,
 ) {}

--- a/src/zipToPosition/zipToPosition.schema.ts
+++ b/src/zipToPosition/zipToPosition.schema.ts
@@ -30,12 +30,10 @@ const OFFICE_TYPES = [
 ] as const
 
 const arrayOrSingle = <T extends z.ZodTypeAny>(inner: T) =>
-  z
-    .union([inner, z.array(inner)])
-    .optional()
-    .transform((v) =>
-      v === undefined ? undefined : Array.isArray(v) ? v : [v],
-    )
+  z.preprocess(
+    (v) => (v === undefined ? undefined : Array.isArray(v) ? v : [v]),
+    z.array(inner).optional(),
+  )
 
 export const SearchPositionsQuerySchema = z
   .object({

--- a/src/zipToPosition/zipToPosition.schema.ts
+++ b/src/zipToPosition/zipToPosition.schema.ts
@@ -1,0 +1,33 @@
+// election-api/src/zipToPosition/zipToPosition.schema.ts
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+const DISPLAY_OFFICE_LEVELS = [
+  'City',
+  'County',
+  'Federal',
+  'Judicial',
+  'Local',
+  'Regional',
+  'State',
+  'Township',
+] as const
+
+export const GetPositionsByZipQuerySchema = z.object({
+  zip: z.string().regex(/^\d{5}$/, 'zip must be 5 digits'),
+  displayOfficeLevels: z
+    .union([
+      z.enum(DISPLAY_OFFICE_LEVELS),
+      z.array(z.enum(DISPLAY_OFFICE_LEVELS)),
+    ])
+    .optional()
+    .transform((v) =>
+      v === undefined ? undefined : Array.isArray(v) ? v : [v],
+    ),
+  electionDateFrom: z.string().date().optional(),
+  electionDateTo: z.string().date().optional(),
+})
+
+export class GetPositionsByZipQueryDTO extends createZodDto(
+  GetPositionsByZipQuerySchema,
+) {}

--- a/src/zipToPosition/zipToPosition.service.test.ts
+++ b/src/zipToPosition/zipToPosition.service.test.ts
@@ -1,4 +1,18 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Test, TestingModule } from '@nestjs/testing'
+import { LoggerModule } from 'nestjs-pino'
+import { randomUUID } from 'node:crypto'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import { PrismaModule } from 'src/prisma/prisma.module'
+import { PrismaService } from 'src/prisma/prisma.service'
 import { ZipToPositionService } from './zipToPosition.service'
 
 describe('ZipToPositionService', () => {
@@ -81,5 +95,126 @@ describe('ZipToPositionService', () => {
         district: null,
       },
     ])
+  })
+})
+
+describe('ZipToPositionService (integration)', () => {
+  let moduleRef: TestingModule
+  let service: ZipToPositionService
+  let prisma: PrismaService
+
+  const placeBeverlyHillsId = randomUUID()
+  const positionBeverlyHillsId = randomUUID()
+  const positionAtlantaId = randomUUID()
+  const ztpBeverlyHillsId = randomUUID()
+  const ztpAtlantaId = randomUUID()
+
+  beforeAll(async () => {
+    moduleRef = await Test.createTestingModule({
+      imports: [
+        LoggerModule.forRoot({ pinoHttp: { level: 'silent' } }),
+        PrismaModule,
+      ],
+      providers: [ZipToPositionService],
+    }).compile()
+    await moduleRef.init()
+
+    service = moduleRef.get(ZipToPositionService)
+    prisma = moduleRef.get(PrismaService)
+  })
+
+  afterAll(async () => {
+    await moduleRef.close()
+  })
+
+  beforeEach(async () => {
+    await prisma.zipToPosition.deleteMany({
+      where: { id: { in: [ztpBeverlyHillsId, ztpAtlantaId] } },
+    })
+    await prisma.position.deleteMany({
+      where: { id: { in: [positionBeverlyHillsId, positionAtlantaId] } },
+    })
+    await prisma.place.deleteMany({ where: { id: placeBeverlyHillsId } })
+
+    await prisma.place.create({
+      data: {
+        id: placeBeverlyHillsId,
+        brDatabaseId: 9001,
+        name: 'Beverly Hills',
+        slug: `ca/beverly-hills-${placeBeverlyHillsId}`,
+        geoId: `geo-${placeBeverlyHillsId}`,
+        state: 'CA',
+      },
+    })
+
+    await prisma.position.createMany({
+      data: [
+        {
+          id: positionBeverlyHillsId,
+          brDatabaseId: 'pos-db-bh',
+          brPositionId: `br-pos-bh-${positionBeverlyHillsId}`,
+          state: 'CA',
+          name: 'Mayor',
+          placeId: placeBeverlyHillsId,
+        },
+        {
+          id: positionAtlantaId,
+          brDatabaseId: 'pos-db-atl',
+          brPositionId: `br-pos-atl-${positionAtlantaId}`,
+          state: 'GA',
+          name: 'City Council',
+        },
+      ],
+    })
+
+    await prisma.zipToPosition.createMany({
+      data: [
+        {
+          id: ztpBeverlyHillsId,
+          positionId: positionBeverlyHillsId,
+          name: 'Mayor',
+          brDatabaseId: 1001,
+          zipCode: '90210',
+          electionYear: 2026,
+          electionDate: new Date('2026-11-03'),
+          displayOfficeLevel: 'City',
+          officeType: 'Mayor',
+          state: 'CA',
+          district: '',
+        },
+        {
+          id: ztpAtlantaId,
+          positionId: positionAtlantaId,
+          name: 'City Council',
+          brDatabaseId: 1002,
+          zipCode: '30303',
+          electionYear: 2026,
+          electionDate: new Date('2026-11-03'),
+          displayOfficeLevel: 'City',
+          officeType: 'City Council',
+          state: 'GA',
+          district: '',
+        },
+      ],
+    })
+  })
+
+  afterEach(async () => {
+    await prisma.zipToPosition.deleteMany({
+      where: { id: { in: [ztpBeverlyHillsId, ztpAtlantaId] } },
+    })
+    await prisma.position.deleteMany({
+      where: { id: { in: [positionBeverlyHillsId, positionAtlantaId] } },
+    })
+    await prisma.place.deleteMany({ where: { id: placeBeverlyHillsId } })
+  })
+
+  it('returns only the row for the requested zip, joined to its Place', async () => {
+    const result = await service.findByZip({ zip: '90210' })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe(ztpBeverlyHillsId)
+    expect(result[0].city).toBe('Beverly Hills')
+    expect(result.find((r) => r.id === ztpAtlantaId)).toBeUndefined()
   })
 })

--- a/src/zipToPosition/zipToPosition.service.test.ts
+++ b/src/zipToPosition/zipToPosition.service.test.ts
@@ -98,123 +98,126 @@ describe('ZipToPositionService', () => {
   })
 })
 
-describe('ZipToPositionService (integration)', () => {
-  let moduleRef: TestingModule
-  let service: ZipToPositionService
-  let prisma: PrismaService
+describe.skipIf(process.env.CI === 'true')(
+  'ZipToPositionService (integration)',
+  () => {
+    let moduleRef: TestingModule
+    let service: ZipToPositionService
+    let prisma: PrismaService
 
-  const placeBeverlyHillsId = randomUUID()
-  const positionBeverlyHillsId = randomUUID()
-  const positionAtlantaId = randomUUID()
-  const ztpBeverlyHillsId = randomUUID()
-  const ztpAtlantaId = randomUUID()
+    const placeBeverlyHillsId = randomUUID()
+    const positionBeverlyHillsId = randomUUID()
+    const positionAtlantaId = randomUUID()
+    const ztpBeverlyHillsId = randomUUID()
+    const ztpAtlantaId = randomUUID()
 
-  beforeAll(async () => {
-    moduleRef = await Test.createTestingModule({
-      imports: [
-        LoggerModule.forRoot({ pinoHttp: { level: 'silent' } }),
-        PrismaModule,
-      ],
-      providers: [ZipToPositionService],
-    }).compile()
-    await moduleRef.init()
+    beforeAll(async () => {
+      moduleRef = await Test.createTestingModule({
+        imports: [
+          LoggerModule.forRoot({ pinoHttp: { level: 'silent' } }),
+          PrismaModule,
+        ],
+        providers: [ZipToPositionService],
+      }).compile()
+      await moduleRef.init()
 
-    service = moduleRef.get(ZipToPositionService)
-    prisma = moduleRef.get(PrismaService)
-  })
-
-  afterAll(async () => {
-    await moduleRef.close()
-  })
-
-  beforeEach(async () => {
-    await prisma.zipToPosition.deleteMany({
-      where: { id: { in: [ztpBeverlyHillsId, ztpAtlantaId] } },
-    })
-    await prisma.position.deleteMany({
-      where: { id: { in: [positionBeverlyHillsId, positionAtlantaId] } },
-    })
-    await prisma.place.deleteMany({ where: { id: placeBeverlyHillsId } })
-
-    await prisma.place.create({
-      data: {
-        id: placeBeverlyHillsId,
-        brDatabaseId: 9001,
-        name: 'Beverly Hills',
-        slug: `ca/beverly-hills-${placeBeverlyHillsId}`,
-        geoId: `geo-${placeBeverlyHillsId}`,
-        state: 'CA',
-      },
+      service = moduleRef.get(ZipToPositionService)
+      prisma = moduleRef.get(PrismaService)
     })
 
-    await prisma.position.createMany({
-      data: [
-        {
-          id: positionBeverlyHillsId,
-          brDatabaseId: 'pos-db-bh',
-          brPositionId: `br-pos-bh-${positionBeverlyHillsId}`,
+    afterAll(async () => {
+      await moduleRef.close()
+    })
+
+    beforeEach(async () => {
+      await prisma.zipToPosition.deleteMany({
+        where: { id: { in: [ztpBeverlyHillsId, ztpAtlantaId] } },
+      })
+      await prisma.position.deleteMany({
+        where: { id: { in: [positionBeverlyHillsId, positionAtlantaId] } },
+      })
+      await prisma.place.deleteMany({ where: { id: placeBeverlyHillsId } })
+
+      await prisma.place.create({
+        data: {
+          id: placeBeverlyHillsId,
+          brDatabaseId: 9001,
+          name: 'Beverly Hills',
+          slug: `ca/beverly-hills-${placeBeverlyHillsId}`,
+          geoId: `geo-${placeBeverlyHillsId}`,
           state: 'CA',
-          name: 'Mayor',
-          placeId: placeBeverlyHillsId,
         },
-        {
-          id: positionAtlantaId,
-          brDatabaseId: 'pos-db-atl',
-          brPositionId: `br-pos-atl-${positionAtlantaId}`,
-          state: 'GA',
-          name: 'City Council',
-        },
-      ],
+      })
+
+      await prisma.position.createMany({
+        data: [
+          {
+            id: positionBeverlyHillsId,
+            brDatabaseId: 'pos-db-bh',
+            brPositionId: `br-pos-bh-${positionBeverlyHillsId}`,
+            state: 'CA',
+            name: 'Mayor',
+            placeId: placeBeverlyHillsId,
+          },
+          {
+            id: positionAtlantaId,
+            brDatabaseId: 'pos-db-atl',
+            brPositionId: `br-pos-atl-${positionAtlantaId}`,
+            state: 'GA',
+            name: 'City Council',
+          },
+        ],
+      })
+
+      await prisma.zipToPosition.createMany({
+        data: [
+          {
+            id: ztpBeverlyHillsId,
+            positionId: positionBeverlyHillsId,
+            name: 'Mayor',
+            brDatabaseId: 1001,
+            zipCode: '90210',
+            electionYear: 2026,
+            electionDate: new Date('2026-11-03'),
+            displayOfficeLevel: 'City',
+            officeType: 'Mayor',
+            state: 'CA',
+            district: '',
+          },
+          {
+            id: ztpAtlantaId,
+            positionId: positionAtlantaId,
+            name: 'City Council',
+            brDatabaseId: 1002,
+            zipCode: '30303',
+            electionYear: 2026,
+            electionDate: new Date('2026-11-03'),
+            displayOfficeLevel: 'City',
+            officeType: 'City Council',
+            state: 'GA',
+            district: '',
+          },
+        ],
+      })
     })
 
-    await prisma.zipToPosition.createMany({
-      data: [
-        {
-          id: ztpBeverlyHillsId,
-          positionId: positionBeverlyHillsId,
-          name: 'Mayor',
-          brDatabaseId: 1001,
-          zipCode: '90210',
-          electionYear: 2026,
-          electionDate: new Date('2026-11-03'),
-          displayOfficeLevel: 'City',
-          officeType: 'Mayor',
-          state: 'CA',
-          district: '',
-        },
-        {
-          id: ztpAtlantaId,
-          positionId: positionAtlantaId,
-          name: 'City Council',
-          brDatabaseId: 1002,
-          zipCode: '30303',
-          electionYear: 2026,
-          electionDate: new Date('2026-11-03'),
-          displayOfficeLevel: 'City',
-          officeType: 'City Council',
-          state: 'GA',
-          district: '',
-        },
-      ],
+    afterEach(async () => {
+      await prisma.zipToPosition.deleteMany({
+        where: { id: { in: [ztpBeverlyHillsId, ztpAtlantaId] } },
+      })
+      await prisma.position.deleteMany({
+        where: { id: { in: [positionBeverlyHillsId, positionAtlantaId] } },
+      })
+      await prisma.place.deleteMany({ where: { id: placeBeverlyHillsId } })
     })
-  })
 
-  afterEach(async () => {
-    await prisma.zipToPosition.deleteMany({
-      where: { id: { in: [ztpBeverlyHillsId, ztpAtlantaId] } },
+    it('returns only the row for the requested zip, joined to its Place', async () => {
+      const result = await service.findByZip({ zip: '90210' })
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe(ztpBeverlyHillsId)
+      expect(result[0].city).toBe('Beverly Hills')
+      expect(result.find((r) => r.id === ztpAtlantaId)).toBeUndefined()
     })
-    await prisma.position.deleteMany({
-      where: { id: { in: [positionBeverlyHillsId, positionAtlantaId] } },
-    })
-    await prisma.place.deleteMany({ where: { id: placeBeverlyHillsId } })
-  })
-
-  it('returns only the row for the requested zip, joined to its Place', async () => {
-    const result = await service.findByZip({ zip: '90210' })
-
-    expect(result).toHaveLength(1)
-    expect(result[0].id).toBe(ztpBeverlyHillsId)
-    expect(result[0].city).toBe('Beverly Hills')
-    expect(result.find((r) => r.id === ztpAtlantaId)).toBeUndefined()
-  })
-})
+  },
+)

--- a/src/zipToPosition/zipToPosition.service.test.ts
+++ b/src/zipToPosition/zipToPosition.service.test.ts
@@ -32,7 +32,7 @@ describe('ZipToPositionService', () => {
   })
 
   it('queries ZipToPosition by zip and date range, joining Position and Place', async () => {
-    await service.findByZip({
+    await service.search({
       zip: '90210',
       electionDateFrom: '2026-01-01',
       electionDateTo: '2027-12-31',
@@ -52,7 +52,7 @@ describe('ZipToPositionService', () => {
   })
 
   it('filters by displayOfficeLevels when provided', async () => {
-    await service.findByZip({
+    await service.search({
       zip: '90210',
       displayOfficeLevels: ['City', 'Township'],
     })
@@ -83,7 +83,7 @@ describe('ZipToPositionService', () => {
       },
     ])
 
-    const result = await service.findByZip({ zip: '90210' })
+    const result = await service.search({ zip: '90210' })
 
     expect(result).toEqual([
       {
@@ -95,6 +95,45 @@ describe('ZipToPositionService', () => {
         district: null,
       },
     ])
+  })
+
+  it('filters by name with case-insensitive substring', async () => {
+    await service.search({ name: 'mayor' })
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          name: { contains: 'mayor', mode: 'insensitive' },
+        }),
+      }),
+    )
+  })
+
+  it('filters by officeType (exact match against array)', async () => {
+    await service.search({ officeType: ['Mayor', 'Sheriff'] })
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          officeType: { in: ['Mayor', 'Sheriff'] },
+        }),
+      }),
+    )
+  })
+
+  it('combines zip + name + officeType when all provided', async () => {
+    await service.search({
+      zip: '90210',
+      name: 'mayor',
+      officeType: ['Mayor'],
+    })
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          zipCode: '90210',
+          name: { contains: 'mayor', mode: 'insensitive' },
+          officeType: { in: ['Mayor'] },
+        }),
+      }),
+    )
   })
 })
 
@@ -212,7 +251,7 @@ describe.skipIf(process.env.CI === 'true')(
     })
 
     it('returns only the row for the requested zip, joined to its Place', async () => {
-      const result = await service.findByZip({ zip: '90210' })
+      const result = await service.search({ zip: '90210' })
 
       expect(result).toHaveLength(1)
       expect(result[0].id).toBe(ztpBeverlyHillsId)

--- a/src/zipToPosition/zipToPosition.service.test.ts
+++ b/src/zipToPosition/zipToPosition.service.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ZipToPositionService } from './zipToPosition.service'
+
+describe('ZipToPositionService', () => {
+  let service: ZipToPositionService
+  let findMany: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    findMany = vi.fn().mockResolvedValue([])
+    service = new ZipToPositionService()
+    Object.defineProperty(service, '_prisma', {
+      value: {
+        zipToPosition: {
+          findMany,
+        },
+      },
+    })
+  })
+
+  it('queries ZipToPosition by zip and date range, joining Position and Place', async () => {
+    await service.findByZip({
+      zip: '90210',
+      electionDateFrom: '2026-01-01',
+      electionDateTo: '2027-12-31',
+    })
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        zipCode: '90210',
+        electionDate: {
+          gte: new Date('2026-01-01'),
+          lte: new Date('2027-12-31'),
+        },
+      },
+      include: { position: { include: { place: true } } },
+      orderBy: [{ electionDate: 'asc' }, { name: 'asc' }],
+    })
+  })
+
+  it('filters by displayOfficeLevels when provided', async () => {
+    await service.findByZip({
+      zip: '90210',
+      displayOfficeLevels: ['City', 'Township'],
+    })
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          zipCode: '90210',
+          displayOfficeLevel: { in: ['City', 'Township'] },
+        }),
+      }),
+    )
+  })
+
+  it('maps a ZipToPosition row + Place into a RaceListItem', async () => {
+    findMany.mockResolvedValue([
+      {
+        id: 'ztp-1',
+        name: 'Mayor',
+        electionDate: new Date('2026-11-03'),
+        displayOfficeLevel: 'City',
+        state: 'CA',
+        district: '',
+        position: {
+          brPositionId: 'br-pos-1',
+          place: { name: 'Beverly Hills' },
+        },
+      },
+    ])
+
+    const result = await service.findByZip({ zip: '90210' })
+
+    expect(result).toEqual([
+      {
+        id: 'ztp-1',
+        brPositionId: 'br-pos-1',
+        position: { name: 'Mayor', level: 'City', state: 'CA' },
+        election: { electionDay: '2026-11-03' },
+        city: 'Beverly Hills',
+        district: null,
+      },
+    ])
+  })
+})

--- a/src/zipToPosition/zipToPosition.service.ts
+++ b/src/zipToPosition/zipToPosition.service.ts
@@ -3,8 +3,10 @@ import { Prisma } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { RaceListItem } from './zipToPosition.types'
 
-type FindByZipParams = {
-  zip: string
+type SearchParams = {
+  zip?: string
+  name?: string
+  officeType?: string[]
   displayOfficeLevels?: string[]
   electionDateFrom?: string
   electionDateTo?: string
@@ -18,9 +20,17 @@ export class ZipToPositionService extends createPrismaBase(
     super()
   }
 
-  async findByZip(params: FindByZipParams): Promise<RaceListItem[]> {
-    const where: Prisma.ZipToPositionWhereInput = {
-      zipCode: params.zip,
+  async search(params: SearchParams): Promise<RaceListItem[]> {
+    const where: Prisma.ZipToPositionWhereInput = {}
+    if (params.zip) where.zipCode = params.zip
+    if (params.name) {
+      where.name = { contains: params.name, mode: 'insensitive' }
+    }
+    if (params.officeType && params.officeType.length > 0) {
+      where.officeType = { in: params.officeType }
+    }
+    if (params.displayOfficeLevels && params.displayOfficeLevels.length > 0) {
+      where.displayOfficeLevel = { in: params.displayOfficeLevels }
     }
     if (params.electionDateFrom || params.electionDateTo) {
       where.electionDate = {
@@ -29,9 +39,6 @@ export class ZipToPositionService extends createPrismaBase(
         }),
         ...(params.electionDateTo && { lte: new Date(params.electionDateTo) }),
       }
-    }
-    if (params.displayOfficeLevels && params.displayOfficeLevels.length > 0) {
-      where.displayOfficeLevel = { in: params.displayOfficeLevels }
     }
 
     const rows = await this.model.findMany({

--- a/src/zipToPosition/zipToPosition.service.ts
+++ b/src/zipToPosition/zipToPosition.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common'
+import { Prisma } from '@prisma/client'
+import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
+import { RaceListItem } from './zipToPosition.types'
+
+type FindByZipParams = {
+  zip: string
+  displayOfficeLevels?: string[]
+  electionDateFrom?: string
+  electionDateTo?: string
+}
+
+@Injectable()
+export class ZipToPositionService extends createPrismaBase(
+  MODELS.ZipToPosition,
+) {
+  constructor() {
+    super()
+  }
+
+  async findByZip(params: FindByZipParams): Promise<RaceListItem[]> {
+    const where: Prisma.ZipToPositionWhereInput = {
+      zipCode: params.zip,
+    }
+    if (params.electionDateFrom || params.electionDateTo) {
+      where.electionDate = {
+        ...(params.electionDateFrom && {
+          gte: new Date(params.electionDateFrom),
+        }),
+        ...(params.electionDateTo && { lte: new Date(params.electionDateTo) }),
+      }
+    }
+    if (params.displayOfficeLevels && params.displayOfficeLevels.length > 0) {
+      where.displayOfficeLevel = { in: params.displayOfficeLevels }
+    }
+
+    const rows = await this.model.findMany({
+      where,
+      include: { position: { include: { place: true } } },
+      orderBy: [{ electionDate: 'asc' }, { name: 'asc' }],
+    })
+
+    return rows.map((row) => ({
+      id: row.id,
+      brPositionId: row.position.brPositionId,
+      position: {
+        name: row.name,
+        level: row.displayOfficeLevel,
+        state: row.state,
+      },
+      election: {
+        electionDay: row.electionDate.toISOString().slice(0, 10),
+      },
+      city: row.position.place?.name ?? null,
+      district: row.district === '' ? null : row.district,
+    }))
+  }
+}

--- a/src/zipToPosition/zipToPosition.types.ts
+++ b/src/zipToPosition/zipToPosition.types.ts
@@ -1,0 +1,15 @@
+export type RaceListItem = {
+  id: string
+  brPositionId: string
+  position: {
+    name: string
+    level: string
+    state: string
+    normalizedPosition?: { name: string }
+  }
+  election: {
+    electionDay: string
+  }
+  city?: string | null
+  district?: string | null
+}


### PR DESCRIPTION
This PR releases election-api to QA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public `GET /positions/search` API backed by Prisma queries; risk is moderate due to new query/filter logic and response mapping that could impact performance or return incorrect results if the underlying `zipToPosition` relations/data vary.
> 
> **Overview**
> Introduces a new `ZipToPositionModule` and wires it into `AppModule`, exposing `GET /positions/search` to search positions by `zip`, `name`, `officeType`, `displayOfficeLevels`, and optional election date range.
> 
> Adds Zod-based query validation/coercion (including single-or-array handling and a “must provide at least one filter” constraint) plus a Prisma-backed service that builds a dynamic `where` clause, joins `position` and `place`, orders results, and maps rows into `RaceListItem`.
> 
> Includes unit tests (and an integration test skipped in CI) covering query construction, filtering behavior, and response mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed1005e4757600201821984079a62e2f487ab9ed. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->