### PR TITLE
Add position level column

### DIFF
--- a/prisma/migrations/20260507161940_add_position_level/migration.sql
+++ b/prisma/migrations/20260507161940_add_position_level/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Position" ADD COLUMN     "level" "PositionLevel";

--- a/prisma/schema/position.prisma
+++ b/prisma/schema/position.prisma
@@ -11,6 +11,8 @@ model Position {
     place      Place?    @relation(fields: [placeId], references: [id])
     placeId    String?   @map("place_id") @db.Uuid()
 
+    level  PositionLevel? @map("level")
+
     ZipToPositions ZipToPosition[]
 
     @@index([placeId])

--- a/src/positions/positions.service.ts
+++ b/src/positions/positions.service.ts
@@ -109,6 +109,7 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
             brDatabaseId: true,
             state: true,
             name: true,
+            level: true,
           },
         })
       if (!position) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk schema change adding a nullable enum column; main risk is any downstream code assuming `Position` has no `level` field or needing backfill/migration handling.
> 
> **Overview**
> Adds an optional `level` field to the `Position` Prisma model, typed as the existing `PositionLevel` enum.
> 
> Includes a database migration that alters the `Position` table to add the new nullable `level` column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65ed99a975d7834384fda6513c94d2dc66c54d29. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->