### PR TITLE
QA <- Dev

### DIFF
--- a/prisma/migrations/20260507161940_add_position_level/migration.sql
+++ b/prisma/migrations/20260507161940_add_position_level/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Position" ADD COLUMN     "level" "PositionLevel";

--- a/prisma/schema/position.prisma
+++ b/prisma/schema/position.prisma
@@ -11,6 +11,8 @@ model Position {
     place      Place?    @relation(fields: [placeId], references: [id])
     placeId    String?   @map("place_id") @db.Uuid()
 
+    level  PositionLevel? @map("level")
+
     ZipToPositions ZipToPosition[]
 
     @@index([placeId])

--- a/src/positions/positions.service.test.ts
+++ b/src/positions/positions.service.test.ts
@@ -69,6 +69,7 @@ describe('PositionsService', () => {
       brDatabaseId: 'db-1',
       state: 'CA',
       name: 'Mayor',
+      level: 'Local',
     })
 
     const result = await service.getPositionById({ id: 'pos-1' })
@@ -81,6 +82,7 @@ describe('PositionsService', () => {
         brDatabaseId: true,
         state: true,
         name: true,
+        level: true,
       },
     })
     expect(result).toEqual({
@@ -89,6 +91,7 @@ describe('PositionsService', () => {
       brDatabaseId: 'db-1',
       state: 'CA',
       name: 'Mayor',
+      level: 'Local',
     })
   })
 

--- a/src/positions/positions.service.ts
+++ b/src/positions/positions.service.ts
@@ -26,6 +26,7 @@ type PositionWithOptionalDistrictAndTurnouts = {
   brDatabaseId: Position['brDatabaseId']
   state: Position['state']
   name: Position['name']
+  level: Position['level']
   district?: {
     id: District['id']
     L2DistrictType: District['L2DistrictType']
@@ -157,9 +158,10 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
     position: PositionWithOptionalDistrictAndTurnouts,
     electionDate?: string,
   ): PositionWithOptionalDistrict {
-    const { id, brPositionId, brDatabaseId, state, name, district } = position
+    const { id, brPositionId, brDatabaseId, state, level, name, district } =
+      position
     if (!district) {
-      return { id, brPositionId, brDatabaseId, state, name }
+      return { id, brPositionId, brDatabaseId, state, name, level }
     }
 
     const {
@@ -183,6 +185,7 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
         state,
         name,
         district: districtResponse,
+        level,
       }
     }
 
@@ -209,6 +212,7 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
       brDatabaseId,
       state,
       name,
+      level,
       district: {
         ...districtResponse,
         projectedTurnout: projectedTurnout ?? null,

--- a/src/positions/positions.service.ts
+++ b/src/positions/positions.service.ts
@@ -109,6 +109,7 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
             brDatabaseId: true,
             state: true,
             name: true,
+            level: true,
           },
         })
       if (!position) {

--- a/src/positions/positions.types.ts
+++ b/src/positions/positions.types.ts
@@ -5,6 +5,7 @@ export type PositionWithOptionalDistrict = Pick<
   'id' | 'brPositionId' | 'brDatabaseId' | 'state'
 > & {
   name?: string | null
+  level: Position['level']
   district?: {
     id: string
     L2DistrictType: string


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a database schema change adding `Position.level`, which requires a migration and can affect existing queries/clients if they start relying on the new field. Service changes are small but the API response typing currently doesn’t expose `level`, so behavior/contract mismatches are possible.
> 
> **Overview**
> Adds an optional `level` column to the `Position` table using the existing `PositionLevel` enum, updating the Prisma `Position` model and including a new migration.
> 
> Updates `PositionsService.findPositionWithOptions` to select the new `level` field when fetching a position without district/turnout data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e72ee3320f4ecc25513e8014871b37f1cf7851c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->