### PR TITLE
fix position return

### DIFF
--- a/src/positions/positions.service.test.ts
+++ b/src/positions/positions.service.test.ts
@@ -69,6 +69,7 @@ describe('PositionsService', () => {
       brDatabaseId: 'db-1',
       state: 'CA',
       name: 'Mayor',
+      level: 'Local',
     })
 
     const result = await service.getPositionById({ id: 'pos-1' })
@@ -81,6 +82,7 @@ describe('PositionsService', () => {
         brDatabaseId: true,
         state: true,
         name: true,
+        level: true,
       },
     })
     expect(result).toEqual({
@@ -89,6 +91,7 @@ describe('PositionsService', () => {
       brDatabaseId: 'db-1',
       state: 'CA',
       name: 'Mayor',
+      level: 'Local',
     })
   })
 

--- a/src/positions/positions.service.ts
+++ b/src/positions/positions.service.ts
@@ -26,6 +26,7 @@ type PositionWithOptionalDistrictAndTurnouts = {
   brDatabaseId: Position['brDatabaseId']
   state: Position['state']
   name: Position['name']
+  level: Position['level']
   district?: {
     id: District['id']
     L2DistrictType: District['L2DistrictType']
@@ -157,9 +158,10 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
     position: PositionWithOptionalDistrictAndTurnouts,
     electionDate?: string,
   ): PositionWithOptionalDistrict {
-    const { id, brPositionId, brDatabaseId, state, name, district } = position
+    const { id, brPositionId, brDatabaseId, state, level, name, district } =
+      position
     if (!district) {
-      return { id, brPositionId, brDatabaseId, state, name }
+      return { id, brPositionId, brDatabaseId, state, name, level }
     }
 
     const {
@@ -183,6 +185,7 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
         state,
         name,
         district: districtResponse,
+        level,
       }
     }
 
@@ -209,6 +212,7 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
       brDatabaseId,
       state,
       name,
+      level,
       district: {
         ...districtResponse,
         projectedTurnout: projectedTurnout ?? null,

--- a/src/positions/positions.types.ts
+++ b/src/positions/positions.types.ts
@@ -5,6 +5,7 @@ export type PositionWithOptionalDistrict = Pick<
   'id' | 'brPositionId' | 'brDatabaseId' | 'state'
 > & {
   name?: string | null
+  level: Position['level']
   district?: {
     id: string
     L2DistrictType: string


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `PositionWithOptionalDistrict` contract and all shaped responses to always include `level`, which may impact downstream consumers expecting the previous response shape.
> 
> **Overview**
> Ensures position lookups consistently return the `Position.level` field.
> 
> Updates `PositionWithOptionalDistrict` to require `level`, and adjusts `PositionsService` query selection and `shapePositionResponse` so `level` is included whether or not `district` and `projectedTurnout` are requested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eefa3482d5390a444338faae2676e04d4c6a10db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->