### PR TITLE
DATA-1896: filter spurious ZIP↔district overlaps in offices-by-zip

### DIFF
--- a/prisma/migrations/20260507200000_add_zip_to_position_overlap_fields/migration.sql
+++ b/prisma/migrations/20260507200000_add_zip_to_position_overlap_fields/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "ZipToPosition" ADD COLUMN     "pct_districtzip_to_zip" DOUBLE PRECISION,
+ADD COLUMN     "voters_in_zip" BIGINT,
+ADD COLUMN     "voters_in_zip_district" BIGINT;
+
+-- CreateIndex
+CREATE INDEX "ZipToPosition_zip_code_pct_districtzip_to_zip_idx" ON "ZipToPosition"("zip_code", "pct_districtzip_to_zip");

--- a/prisma/schema/zipToPosition.prisma
+++ b/prisma/schema/zipToPosition.prisma
@@ -26,11 +26,6 @@ model ZipToPosition {
   state              String @db.Char(2)
   district           String
 
-  // Overlap-quality fields (DATA-1896): expose the dbt-computed voter counts
-  // and the derived percentage so this service can filter spurious ZIP↔
-  // district overlaps (e.g., a handful of West Hollywood voters scattered
-  // into 90210). Nullable for the deploy window between this Prisma migration
-  // and the first sync_election_api run that populates them.
   votersInZip         BigInt? @map("voters_in_zip")
   votersInZipDistrict BigInt? @map("voters_in_zip_district")
   pctDistrictzipToZip Float?  @map("pct_districtzip_to_zip")

--- a/prisma/schema/zipToPosition.prisma
+++ b/prisma/schema/zipToPosition.prisma
@@ -26,7 +26,17 @@ model ZipToPosition {
   state              String @db.Char(2)
   district           String
 
+  // Overlap-quality fields (DATA-1896): expose the dbt-computed voter counts
+  // and the derived percentage so this service can filter spurious ZIP↔
+  // district overlaps (e.g., a handful of West Hollywood voters scattered
+  // into 90210). Nullable for the deploy window between this Prisma migration
+  // and the first sync_election_api run that populates them.
+  votersInZip         BigInt? @map("voters_in_zip")
+  votersInZipDistrict BigInt? @map("voters_in_zip_district")
+  pctDistrictzipToZip Float?  @map("pct_districtzip_to_zip")
+
   @@unique([zipCode, positionId, electionDate])
   @@index([zipCode])
   @@index([positionId])
+  @@index([zipCode, pctDistrictzipToZip])
 }

--- a/src/zipToPosition/zipToPosition.service.test.ts
+++ b/src/zipToPosition/zipToPosition.service.test.ts
@@ -40,6 +40,10 @@ describe('ZipToPositionService', () => {
 
     expect(findMany).toHaveBeenCalledWith({
       where: {
+        OR: [
+          { pctDistrictzipToZip: null },
+          { pctDistrictzipToZip: { gte: 0.005 } },
+        ],
         zipCode: '90210',
         electionDate: {
           gte: new Date('2026-01-01'),
@@ -49,6 +53,21 @@ describe('ZipToPositionService', () => {
       include: { position: { include: { place: true } } },
       orderBy: [{ electionDate: 'asc' }, { name: 'asc' }],
     })
+  })
+
+  it('always applies the null-safe pct_districtzip_to_zip threshold filter', async () => {
+    await service.search({ zip: '90210' })
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            { pctDistrictzipToZip: null },
+            { pctDistrictzipToZip: { gte: 0.005 } },
+          ],
+        }),
+      }),
+    )
   })
 
   it('filters by displayOfficeLevels when provided', async () => {

--- a/src/zipToPosition/zipToPosition.service.ts
+++ b/src/zipToPosition/zipToPosition.service.ts
@@ -3,6 +3,15 @@ import { Prisma } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { RaceListItem } from './zipToPosition.types'
 
+// DATA-1896: minimum fraction of a zip's L2 voters that must live in a
+// district for that (zip, position) overlap to surface here. Tunable via
+// env so the threshold can be moved without a deploy. Rows below the
+// threshold are kept in the table (so a future "see more" UX can read
+// them); this endpoint just hides them.
+const PCT_DISTRICTZIP_TO_ZIP_THRESHOLD = Number(
+  process.env.PCT_DISTRICTZIP_TO_ZIP_THRESHOLD ?? 0.005,
+)
+
 type SearchParams = {
   zip?: string
   name?: string
@@ -21,7 +30,17 @@ export class ZipToPositionService extends createPrismaBase(
   }
 
   async search(params: SearchParams): Promise<RaceListItem[]> {
-    const where: Prisma.ZipToPositionWhereInput = {}
+    const where: Prisma.ZipToPositionWhereInput = {
+      // Null-safe overlap-quality gate. The IS NULL branch covers the
+      // deploy window between this Prisma migration and the first
+      // sync_election_api run that populates the new columns; once
+      // the sync completes, all rows have non-null values and the
+      // null branch is defense in depth.
+      OR: [
+        { pctDistrictzipToZip: null },
+        { pctDistrictzipToZip: { gte: PCT_DISTRICTZIP_TO_ZIP_THRESHOLD } },
+      ],
+    }
     if (params.zip) where.zipCode = params.zip
     if (params.name) {
       where.name = { contains: params.name, mode: 'insensitive' }

--- a/src/zipToPosition/zipToPosition.service.ts
+++ b/src/zipToPosition/zipToPosition.service.ts
@@ -3,11 +3,6 @@ import { Prisma } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { RaceListItem } from './zipToPosition.types'
 
-// DATA-1896: minimum fraction of a zip's L2 voters that must live in a
-// district for that (zip, position) overlap to surface here. Tunable via
-// env so the threshold can be moved without a deploy. Rows below the
-// threshold are kept in the table (so a future "see more" UX can read
-// them); this endpoint just hides them.
 const PCT_DISTRICTZIP_TO_ZIP_THRESHOLD = Number(
   process.env.PCT_DISTRICTZIP_TO_ZIP_THRESHOLD ?? 0.005,
 )
@@ -31,11 +26,6 @@ export class ZipToPositionService extends createPrismaBase(
 
   async search(params: SearchParams): Promise<RaceListItem[]> {
     const where: Prisma.ZipToPositionWhereInput = {
-      // Null-safe overlap-quality gate. The IS NULL branch covers the
-      // deploy window between this Prisma migration and the first
-      // sync_election_api run that populates the new columns; once
-      // the sync completes, all rows have non-null values and the
-      // null branch is defense in depth.
       OR: [
         { pctDistrictzipToZip: null },
         { pctDistrictzipToZip: { gte: PCT_DISTRICTZIP_TO_ZIP_THRESHOLD } },

--- a/src/zipToPosition/zipToPosition.service.ts
+++ b/src/zipToPosition/zipToPosition.service.ts
@@ -3,9 +3,8 @@ import { Prisma } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { RaceListItem } from './zipToPosition.types'
 
-const PCT_DISTRICTZIP_TO_ZIP_THRESHOLD = Number(
-  process.env.PCT_DISTRICTZIP_TO_ZIP_THRESHOLD ?? 0.005,
-)
+const PCT_DISTRICTZIP_TO_ZIP_THRESHOLD =
+  Number(process.env.PCT_DISTRICTZIP_TO_ZIP_THRESHOLD) || 0.005
 
 type SearchParams = {
   zip?: string


### PR DESCRIPTION
Companion to **[gp-data-platform#370](https://github.com/thegoodparty/gp-data-platform/pull/370)** — the dbt mart now exposes overlap-quality columns; this PR adds them to `ZipToPosition` and applies the threshold filter in `ZipToPositionService.search`.

Default threshold `0.005` (0.5% of zip's L2 voters); tunable via `PCT_DISTRICTZIP_TO_ZIP_THRESHOLD` env. Filter is null-safe: rows where `pct_districtzip_to_zip IS NULL` pass through (covers positions without zip coverage from the mart's LEFT JOIN, plus the brief deploy window before the first post-migration sync). Below-threshold rows stay in the table so a future "see more" UX can surface them.

### Verification (90210 / CA, City overlaps)

| district | voters | pct | result |
|---|---|---|---|
| BEVERLY HILLS CITY | 9,714 | 61.9% | INCLUDE |
| LOS ANGELES CITY | 5,968 | 38.0% | INCLUDE |
| WEST HOLLYWOOD CITY | 6 | 0.04% | EXCLUDE ✓ |

Tests: 30 passed, 1 skipped (CI-skipped integration test that hits dev DB).

### Deploy order

1. Pause `sync_election_api` DAG.
2. Merge gp-data-platform#370.
3. `dbt build --full-refresh` on the three modified models.
4. **Merge this PR** — Prisma adds nullable columns + composite index `ZipToPosition_zip_code_pct_districtzip_to_zip_idx`.
5. Unpause the DAG. First sync populates the new columns; swap renames the new index (which exists on prod from step 4).

### Heads-up

`prisma migrate diff` against develop also showed unrelated drift on `Position` (a `column_6` in the live DB but not in the schema). Not included in this migration — out of scope and destructive. Worth a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)