### PR TITLE
Eng 10170 claude

### DIFF
--- a/.claude/agents/code-critic.md
+++ b/.claude/agents/code-critic.md
@@ -1,0 +1,47 @@
+---
+name: code-critic
+description: Reviews recent code changes against the rule files in ai-rules/. Use after a substantive change (a feature, a refactor, a bug fix that touches multiple files) and before opening a PR. Cites specific rules when flagging issues.
+---
+
+You are a code-critic agent for `election-api`. Your job is to review recent code changes against the org's review rules.
+
+## Inputs
+
+- The user's diff or list of files changed (assume staged/unstaged changes if not given).
+- The rule files in `ai-rules/` at the repo root (a git submodule). Each `.md` file in the top level of `ai-rules/` is one rule set.
+
+## Process
+
+1. Identify the files changed (`git diff --name-only` if no list is supplied).
+2. List the rule files in `ai-rules/`: `breaking-changes.md`, `bugs.md`, `code-duplication.md`, `security.md`, `test-engineer.md`, `ts-engineer.md`. Skip the templates and skills/ directory — those are not review rules.
+3. Read each rule file in full. Do not skim — they're short by design.
+4. For each rule file, review the diff against its rules. For every violation:
+   - Cite the rule file and the specific rule (e.g., `ts-engineer.md` rule #3).
+   - Quote the offending code with file path + line numbers.
+   - Explain what to change and why.
+5. Cross-reference repo conventions in `CLAUDE.md` and `docs/architecture.md` — flag deviations with the same evidence-quote-fix structure.
+
+## Output format
+
+Group findings by severity:
+
+- **Blockers** — bugs, security issues, breaking-change risks. Must be fixed before merge.
+- **Should-fix** — duplication, type-safety relaxations, missing tests where rules require them.
+- **Nits** — style or naming suggestions. Optional.
+
+Each finding:
+
+```
+[<file>:<line>] <rule-file> — <one-line headline>
+  > <quoted offending code>
+  Why: <explanation>
+  Fix: <what to change>
+```
+
+If there are no findings in a category, omit it.
+
+## Never
+
+- Never invent a rule. If the rule file doesn't say it, don't flag it.
+- Never recommend changes outside the diff scope. Stay on the changes the user is shipping.
+- Never claim a rule applies without quoting it.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ai-rules"]
+	path = ai-rules
+	url = https://github.com/thegoodparty/ai-rules.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+Guidance for Claude Code and other AI agents working in `election-api`. Keep this file short — push detail into `docs/`.
+
+## Project
+
+NestJS/Fastify API serving public election and political candidacy data for GoodParty.org (places, races, positions, candidacies, districts). Postgres via Prisma. Internal service — called by `gp-api`, not exposed to end users.
+
+## Commands (most-used first)
+
+```bash
+npm run start:dev              # Dev server (:3000) with watch
+npm test                       # vitest run
+npx vitest run src/path/to/file.test.ts        # single file
+npx vitest                     # watch mode
+npm run lint                   # eslint --fix on {src,apps,libs,test}/**/*.ts
+npm run lint-format            # lint + prettier --write
+npm run build                  # nest build → dist/
+
+npm run migrate:dev            # create/apply a migration
+npm run migrate:reset          # reset DB + migrate (LOCAL ONLY)
+npm run migrate:deploy         # apply pending migrations (CI/prod)
+npm run generate               # regenerate Prisma client
+```
+
+`npm run lint` runs `eslint --fix` — it mutates files. Stage your work first.
+
+## Pointer table — when in doubt
+
+| Doing | Read |
+|-------|------|
+| Adding an endpoint / module | `docs/architecture.md` § Module shape |
+| Querying data / adding a Prisma model | `docs/data-model.md` |
+| First-time setup | `docs/getting-started.md` |
+| AI rule-by-rule code review | `ai-rules/` (git submodule) |
+
+## Code style
+
+- **No semicolons**, single quotes, trailing commas (`.prettierrc`)
+- `unused-imports/no-unused-imports` is an **error**
+- `@typescript-eslint/no-explicit-any` is currently **off** (relaxed). Prefer typed code anyway — `any` should be a last resort, not a habit.
+- `noImplicitAny` is `false` and `tsconfig` `baseUrl` is `./`, so imports look like `import { X } from 'src/<feature>/...'` rather than `@/<feature>/...`.
+- Arrow functions over `function` declarations
+- Bias to WET over premature DRY
+
+## Module shape
+
+```
+src/<feature>/
+├── <feature>.module.ts
+├── <feature>.controller.ts        # HTTP only
+├── <feature>.service.ts           # extends createPrismaBase(MODELS.X)
+├── <feature>.schema.ts            # Zod via nestjs-zod's createZodDto
+├── <feature>.types.ts             # optional — type predicates / shared narrows
+└── <feature>.service.test.ts      # vitest, colocated
+```
+
+`src/places/` is a clean reference module to copy.
+
+## PrismaBase pattern
+
+Services backed by a Prisma model **must** extend `createPrismaBase(MODELS.ModelName)` from `src/prisma/util/prisma.util.ts`. Provides `this.model`, `this.client`, `this.logger`, and bound passthroughs (`findMany`, `findFirst`, `findUnique`, `count`, etc.).
+
+```ts
+@Injectable()
+export class PlacesService extends createPrismaBase(MODELS.Place) {
+  constructor() {
+    super()
+  }
+}
+```
+
+## Validation
+
+Request validation uses `nestjs-zod`'s `createZodDto(zodSchema)` + the global `ZodValidationPipe` registered in `src/main.ts`. Define the schema, export a DTO class via `createZodDto`, and bind it to the controller param with `@Query() / @Param() / @Body()`.
+
+Never bypass the DTO and read `request` raw — the global pipe is what enforces the schema.
+
+## Testing
+
+- Framework: **Vitest** with SWC (NestJS decorator metadata requires SWC, not esbuild)
+- Test file pattern: `*.test.ts` colocated with source (NOT `.spec.ts`)
+- Loads `.env.test`; `clearMocks: true` between tests
+- Pattern: direct instantiation + `Object.defineProperty(service, '_prisma', { value: { ... } })` to inject a mocked client. See `src/places/places.service.test.ts` for the canonical shape.
+
+## Never
+
+- Never edit a file under `prisma/migrations/<timestamp>/` — applied migrations are immutable.
+- Never expose this API to public traffic. It's an internal service consumed by `gp-api`; auth is network-level (VPC/SG).
+- Never bypass `createZodDto` for request validation — the global `ZodValidationPipe` is the only enforcement point.
+- Never disable `unused-imports/no-unused-imports` without an inline comment justifying it.
+- Never add `any` casually — the rule is off, but typed code is still the bar.
+
+## Environment
+
+- Node `v22.12` (`.nvmrc`)
+- npm (no `--legacy-peer-deps` needed)
+- Postgres for local dev; `DATABASE_URL` in `.env`
+- `node-gyp` prerequisites required for native deps (`libpg-query`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,89 @@
+# Architecture
+
+A pointer-heavy doc. Detailed conventions live in `CLAUDE.md` and the rule files in `ai-rules/`.
+
+## Stack
+
+- **NestJS 11** on **Fastify** (not Express)
+- **Prisma 6** with multi-file schema folder (`previewFeatures = ["prismaSchemaFolder"]`); `prisma-json-types-generator` for JSON column typing
+- **Zod** via `nestjs-zod` (`createZodDto` + global `ZodValidationPipe`) for request validation
+- **Vitest 4** with SWC for tests (esbuild can't emit decorator metadata; SWC can)
+- **OpenTelemetry** (traces/metrics/logs OTLP) wired in `src/otel.ts`; `nestjs-pino` for structured logs
+- **Pulumi** (TypeScript) for IaC under `deploy/`
+
+## Module shape
+
+```
+src/<feature>/
+├── <feature>.module.ts
+├── <feature>.controller.ts        # HTTP only — no business logic
+├── <feature>.service.ts           # extends createPrismaBase(MODELS.X)
+├── <feature>.schema.ts            # Zod schemas + createZodDto classes
+├── <feature>.types.ts             # optional — narrowing helpers / shared TS types
+├── <feature>.util.ts              # optional — pure helpers
+└── <feature>.service.test.ts      # vitest, colocated
+```
+
+`src/places/` is the cleanest reference module. Start there if you need a pattern to copy.
+
+`PrismaModule` is `@Global` (`src/prisma/prisma.module.ts`) so feature modules don't import it explicitly except where they want to be self-documenting (e.g. `src/places/places.module.ts` lists it).
+
+## HTTP surface
+
+All routes are mounted under the global prefix `v1` (set in `src/main.ts`). Controllers live at `src/<feature>/<feature>.controller.ts`:
+
+| Path | Module |
+|------|--------|
+| `GET /v1/health` | `src/health/` |
+| `GET /v1/places`, `/places/by-position-id/:id`, `/places/most-elections` | `src/places/` |
+| `GET /v1/districts/list`, `/types`, `/names`, `/:id` | `src/districts/` |
+| `GET /v1/positions/by-ballotready-id/:id`, `/:id` | `src/positions/` |
+| `GET /v1/positions/search` (ZIP → position lookup) | `src/zipToPosition/` |
+| `GET /v1/candidacies` | `src/candidacies/` |
+| `GET /v1/races` | `src/races/` |
+| `GET /v1/projectedTurnout` | `src/projectedTurnout/` |
+| `GET /v1/voter-issues` | `src/voterIssues/` |
+
+Swagger is mounted at `/api` (no prefix) for ad-hoc exploration in non-prod.
+
+## Auth
+
+There is no application-level auth. `election-api` is an **internal** service — the only callers are `gp-api` and other internal services inside the VPC. Network-level controls (VPC, security groups in `deploy/components/`) are the boundary. Don't add public endpoints without first changing this assumption.
+
+CORS is open (`origin: '*'`) for the same reason — change `CORS_ORIGIN` in env if/when this is no longer internal-only.
+
+## Cross-service edges
+
+| Direction | Service | Protocol | Notes |
+|-----------|---------|----------|-------|
+| inbound | `gp-api` | HTTP (internal) | The primary consumer; relays election-api responses to webapp users |
+| inbound | `gp-data-platform` (read) | Postgres direct | ETL writes/reads via direct DB connection |
+| outbound | none in app code | — | Data ingestion happens in `gp-data-platform`, not here |
+
+No shared TS types package today — each side declares its own DTOs. If/when contracts are needed across the gp-api ↔ election-api edge, they'll go through `@goodparty_org/contracts` (lives in `gp-api`).
+
+See `ai-rules/system-map.md` for the full cross-repo map.
+
+## Bootstrap
+
+`src/main.ts` is the entry point. In order:
+
+1. Load alias + dotenv (`module-alias`, `src/configrc.ts`)
+2. Create `NestFastifyApplication` with `rawBody: true` and a UUID `genReqId`
+3. Swap in `nestjs-pino` as the global logger
+4. Register Fastify OTel instrumentation (when present in global)
+5. Set global prefix `v1`, register `ZodValidationPipe`, register `AllExceptionsFilter`
+6. Build Swagger doc at `/api`
+7. Register `@fastify/helmet`, `@fastify/cors`, `@fastify/static` (serves `public/`)
+8. Listen on `PORT` (default 3000)
+
+## Key patterns
+
+- **`createPrismaBase(MODELS.X)`** (`src/prisma/util/prisma.util.ts`) — every service backed by a Prisma model extends this. Gives `this.model`, `this.client`, `this.logger`, and bound passthroughs (`findMany`, `findFirst`, `findUnique`, `findUniqueOrThrow`, `count`).
+- **`createZodDto(zodSchema)`** — `nestjs-zod` decorator-friendly DTO. Bind to `@Query()`/`@Param()`/`@Body()`; the global `ZodValidationPipe` enforces it. Inputs that come from query strings often need `z.preprocess(...)` to coerce strings to booleans/numbers.
+- **`AllExceptionsFilter`** (`src/shared/filters/allExceptions.filter.ts`) — global filter that returns the real error message for non-`HttpException` errors. Safe because the API is internal-only; aids debugging from gp-api.
+- **`buildColumnSelect`** (`src/prisma/util/prisma.util.ts`) — builds a typed Prisma `select` clause from a comma-separated string of column names, used by endpoints that let callers pick fields.
+
+## ADRs
+
+`docs/adr/` is not yet seeded for this repo. Add one when a non-obvious decision lands (e.g., why network-level auth instead of JWT, why nestjs-zod vs raw Zod). Use `ai-rules/adr-template.md`.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,78 @@
+# Data Model
+
+The Prisma schema is split across one file per model under `prisma/schema/` (enabled by the `prismaSchemaFolder` preview feature in `prisma/schema/schema.prisma`). All entities use UUID primary keys, snake_case columns mapped via `@map`, and the standard `createdAt`/`updatedAt` audit fields.
+
+## Entities
+
+### `Place` — `prisma/schema/place.prisma`
+A geographic entity (state, county, city, township, etc.) identified by a Census `geoId`. Self-referential parent/child relation forms a hierarchy via `PlaceHierarchy`. Sources demographics ("fun facts": population, density, income, home value, unemployment).
+- **Unique:** `slug` (e.g., `tx/hidalgo/mission`), `geoId`
+- **Relations:** `Race[]`, `Position[]`, recursive `Place[]` parent/children
+- **Notes:** `mtfcc` is the Census MAF/TIGER feature class code; `state` is `Char(2)`
+
+### `Race` — `prisma/schema/race.prisma`
+A specific election contest at a `Place` for a particular position on a particular `electionDate`. Carries Ballotready (`brHashId`, `brDatabaseId`) and per-race metadata (filing window, eligibility, salary, partisan/runoff/primary flags).
+- **Indexed:** `slug`
+- **Relations:** `Place?`, `Candidacy[]`
+- **Enum:** `PositionLevel { CITY, COUNTY, FEDERAL, LOCAL, REGIONAL, STATE, TOWNSHIP }`
+
+### `Candidacy` — `prisma/schema/candidacy.prisma`
+A person running in a `Race`. Denormalizes parts of the candidate's Person + Position records from Ballotready (first/last name, party, image, about, urls, salary, election frequency, normalized position name).
+- **Unique:** `slug` (slugified `firstName-lastName-normalizedPositionName`)
+- **Relations:** `Race?`, `Stance[]`
+- **Enum:** `ElectionResult { WON, LOST, RUNOFF }`
+
+### `Position` — `prisma/schema/position.prisma`
+The "office being run for" — a Ballotready position scoped to a `District` and/or `Place`. The bridge between geography and `Race`.
+- **Unique:** `brPositionId` (the Ballotready source position id — must be unique)
+- **Indexed:** `placeId`
+- **Relations:** `District?`, `Place?`, `ZipToPosition[]`
+- **Note:** `brDatabaseId` is a `String` here (outlier — the rest of the schema uses `Int`). Don't propagate this style; see `ZipToPosition` for the rationale.
+
+### `District` — `prisma/schema/district.prisma`
+An L2 voter-file district (e.g., a state house district, a school board district). Identified uniquely by `(state, L2DistrictType, L2DistrictName)`.
+- **Relations:** `ProjectedTurnout[]`, `Position[]`, `DistrictTopIssue[]`
+
+### `DistrictTopIssue` — `prisma/schema/districtTopIssue.prisma`
+Top political issues per district, sourced from Haystaq voter scoring. `score` is the average Haystaq score (0-100), `issueRank` is the rank within the district (1 = highest).
+- **Unique:** `(districtId, issue)`
+
+### `ProjectedTurnout` — `prisma/schema/projectedTurnout.prisma`
+Modeled turnout for a district in a given election year. Stamped with `inferenceAt` and `modelVersion` so callers can reason about freshness.
+- **Indexed:** `(districtId, electionYear)`
+- **Enum:** `ElectionCode { General, LocalOrMunicipal, ConsolidatedGeneral }`
+- **Note:** physically mapped to `Projected_Turnout` (snake_case + Pascal — preserved from the upstream ETL)
+
+### `Issue` — `prisma/schema/issue.prisma`
+A Ballotready-sourced political issue. Self-referential `IssueHierarchy` for parent/child topic structure.
+- **Relations:** `Issue?` parent, `Issue[]` children, `Stance[]`
+
+### `Stance` — `prisma/schema/stance.prisma`
+A candidate's stance on an issue. Stored verbatim from Ballotready (`stanceStatement`, `stanceReferenceUrl`, `stanceLocale`).
+- **Relations:** `Issue` (required), `Candidacy?`
+
+### `ZipToPosition` — `prisma/schema/zipToPosition.prisma`
+Denormalized ZIP → position rollup, sourced from a dbt mart in `gp-data-platform`. Lets API callers find positions by ZIP without joining `Position` + geographic tables.
+- **Unique:** `(zipCode, positionId, electionDate)`
+- **Indexed:** `zipCode`, `positionId`, `(zipCode, pctDistrictzipToZip)`
+- **Note:** Field names + `accepted_values` constraints are dictated by the upstream dbt model. The `brDatabaseId Int` choice intentionally diverges from `Position.brDatabaseId String` to match the mart and the rest of the schema.
+
+## Common query patterns
+
+- **Find a place by hierarchy slug** — `slug` is unique on `Place`; query `where: { slug }` then optionally include `parent` / `children`. See `src/places/places.service.ts`.
+- **Position lookup from a ZIP** — query `ZipToPosition` by `zipCode`; the row carries denormalized `displayOfficeLevel`, `officeType`, `district`, etc. so the response can be built without a join.
+- **Candidate cards for a race** — `Race.findUnique({ where: { slug }, include: { Candidacies: { include: { Stances: { include: { Issue: true } } } } } })`.
+- **Top issues by district** — `DistrictTopIssue.findMany({ where: { districtId }, orderBy: { issueRank: 'asc' } })`.
+
+## Conventions
+
+- All PKs are `String @id @db.Uuid`. Generate UUIDs in app code, not at the DB.
+- `@map("snake_case")` on every column; Prisma model names stay PascalCase.
+- Add `@@map("...")` only when the table physical name diverges from the Prisma model name (e.g., `Projected_Turnout`).
+- Indexes for any field commonly used in `where` — see existing schemas for examples (`positionId`, `placeId`, `zipCode`).
+- `String[]` arrays are used liberally (party, urls, electionFrequency, positionNames). Don't normalize these into join tables without a real querying need; they're write-once from the upstream ETL.
+- **Never edit applied migrations under `prisma/migrations/<timestamp>/`** — they're immutable. Create a new migration with `npm run migrate:dev`.
+
+## Source of truth
+
+Most rows are populated by ETL in `gp-data-platform`, not by this API. `election-api` is read-mostly from the application's perspective. New columns / models are typically added in the ETL first, then surfaced here via a new migration.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,106 @@
+# Getting Started
+
+First-time setup for `election-api` on macOS / Linux. Should take ~10 minutes once Postgres is running.
+
+## Prerequisites
+
+- **Node** matching `.nvmrc` (`v22.12`). If you use `nvm`: `nvm install && nvm use`.
+- **npm** (ships with Node).
+- **PostgreSQL** running locally on `:5432`. Easiest path is Docker:
+  ```bash
+  docker run --name election-api-pg -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres:15
+  ```
+  Or use Postgres.app / Homebrew.
+- **node-gyp prerequisites** for your OS — required by `libpg-query` (a native dep). See https://github.com/nodejs/node-gyp#on-unix.
+
+## Clone
+
+This repo uses `ai-rules` as a git submodule. Clone with `--recursive`:
+
+```bash
+git clone --recursive git@github.com:thegoodparty/election-api.git
+cd election-api
+```
+
+If you already cloned without `--recursive`:
+
+```bash
+git submodule update --init --recursive
+```
+
+`npm install` also runs `git submodule update --init --recursive` via the `postinstall` hook, so for fresh clones the submodule will populate either way.
+
+## Configure environment
+
+Copy `.env.example` to `.env` and fill in:
+
+```bash
+cp .env.example .env
+```
+
+Required vars:
+
+| Var | Default for local | Notes |
+|-----|-------------------|-------|
+| `DATABASE_URL` | `postgresql://postgres:postgres@localhost:5432/electiondb` | Postgres connection string |
+| `CORS_ORIGIN` | `http://localhost:4000` | Origin allowed by Fastify CORS |
+| `LOG_LEVEL` | `debug` | `debug` enables Prisma query logs in dev |
+
+`.env.test` mirrors `.env` for the vitest suite (already committed).
+
+## Install + generate
+
+```bash
+nvm use            # if you use nvm
+npm install        # also pulls the ai-rules submodule
+npm run generate   # generate the Prisma client
+```
+
+## Set up the database
+
+```bash
+npm run migrate:reset    # wipes + recreates DB, applies all migrations
+```
+
+There's **no seed script** in this repo today — most data is populated by the ETL in `gp-data-platform`. For local exploration you can either:
+- Connect to a copy of dev data (ask in #engineering for current setup), or
+- Create rows manually via a `psql` session against the local DB.
+
+## Run
+
+```bash
+npm run start:dev    # http://localhost:3000  (watch mode)
+```
+
+Health check: `curl http://localhost:3000/v1/health`. Swagger UI: http://localhost:3000/api.
+
+## Test
+
+```bash
+npm test                                          # full suite
+npx vitest run src/places/places.service.test.ts  # single file
+npx vitest                                        # watch mode
+```
+
+Tests load `.env.test` automatically (via `vitest.config.ts`).
+
+## Lint + format
+
+```bash
+npm run lint            # eslint --fix; mutates files — stage your work first
+npm run lint-format     # lint + prettier --write
+```
+
+## Common gotchas
+
+- **`prisma generate` not run** → TS errors complaining about missing types from `@prisma/client`. Run `npm run generate`.
+- **`libpg-query` failed to build** → missing node-gyp prereqs (Xcode CLT on macOS, `build-essential` on Debian/Ubuntu).
+- **Port 3000 in use** → set `PORT=3001` in `.env`, or stop the conflicting process.
+- **Submodule directory empty** → `git submodule update --init --recursive`.
+
+## Where to go next
+
+- `CLAUDE.md` — agent + style guide for the repo.
+- `docs/architecture.md` — module shape, HTTP surface, cross-service edges.
+- `docs/data-model.md` — Prisma entities and how they relate.
+- `ai-rules/` — org-wide review rules and skills (submodule).

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "election-api",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "CC0-1.0",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "license": "CC0-1.0",
   "scripts": {
+    "postinstall": "git submodule update --init --recursive",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\"",
     "start": "nest start",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to developer tooling/docs and an install-time submodule update; main behavior impact is potential install friction if git/submodules aren’t available in CI or some environments.
> 
> **Overview**
> Adds a new `.claude/agents/code-critic.md` agent that reviews diffs against the org’s `ai-rules/` rule sets and standardizes how findings are reported.
> 
> Introduces `ai-rules` as a git submodule (`.gitmodules`) and ensures it’s initialized via a new `postinstall` script in `package.json` (reflected in `package-lock.json`).
> 
> Adds repo-facing guidance docs (`CLAUDE.md`, `docs/architecture.md`, `docs/data-model.md`, `docs/getting-started.md`) to document conventions and setup, including submodule usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9ff2dd8738c53fe94b3f8685ffe6a7cf5e25a04. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->