### PR TITLE
[DATA-1903] DistrictTopIssue jurisdictional flags + voter-issues filter

### DIFF
--- a/prisma/migrations/20260513035356_add_district_top_issue_jurisdiction_flags/migration.sql
+++ b/prisma/migrations/20260513035356_add_district_top_issue_jurisdiction_flags/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "DistrictTopIssue" ADD COLUMN     "is_local" BOOLEAN,
+ADD COLUMN     "is_regional" BOOLEAN,
+ADD COLUMN     "is_state" BOOLEAN,
+ADD COLUMN     "is_federal" BOOLEAN;

--- a/prisma/schema/districtTopIssue.prisma
+++ b/prisma/schema/districtTopIssue.prisma
@@ -8,11 +8,21 @@ model DistrictTopIssue {
 
   // Haystaq issue score column name (e.g. hs_charter_schools_support)
   issue      String
-  issueLabel String @map("issue_label")
+  issueLabel String   @map("issue_label")
   // Average Haystaq score across voters in the district (0-100)
   score      Float
+  // Jurisdictional flags from gp-data-platform DATA-1903: the level(s) of
+  // government where this issue is actionable. Not mutually exclusive — an
+  // issue can be actionable at multiple levels. Nullable while the
+  // gp-data-platform phase-(c) Airflow sync work is in flight; values are
+  // populated by the next sync_election_api run after that PR lands. May
+  // tighten to non-nullable in a follow-up once data is verified.
+  isLocal    Boolean? @map("is_local")
+  isRegional Boolean? @map("is_regional")
+  isState    Boolean? @map("is_state")
+  isFederal  Boolean? @map("is_federal")
   // Rank of the issue within the district (1 = highest score)
-  issueRank  Int @map("issue_rank")
+  issueRank  Int      @map("issue_rank")
 
   @@unique([districtId, issue])
 }

--- a/src/voterIssues/voterIssues.controller.test.ts
+++ b/src/voterIssues/voterIssues.controller.test.ts
@@ -30,4 +30,20 @@ describe('VoterIssuesController', () => {
     })
     expect(result).toEqual(issues)
   })
+
+  it('forwards the level filter to the service when provided', async () => {
+    getVoterIssues.mockResolvedValue([])
+
+    await controller.getVoterIssues({
+      districtId: 'd-1',
+      limit: 10,
+      level: 'local',
+    })
+
+    expect(getVoterIssues).toHaveBeenCalledWith({
+      districtId: 'd-1',
+      limit: 10,
+      level: 'local',
+    })
+  })
 })

--- a/src/voterIssues/voterIssues.controller.ts
+++ b/src/voterIssues/voterIssues.controller.ts
@@ -13,6 +13,7 @@ export class VoterIssuesController {
     return this.voterIssues.getVoterIssues({
       districtId: query.districtId,
       limit: query.limit,
+      ...(query.level !== undefined && { level: query.level }),
     })
   }
 }

--- a/src/voterIssues/voterIssues.schema.ts
+++ b/src/voterIssues/voterIssues.schema.ts
@@ -4,7 +4,10 @@ import { z } from 'zod'
 const getVoterIssuesQuerySchema = z.object({
   districtId: z.string().uuid(),
   limit: z.coerce.number().int().positive().max(50).optional().default(10),
+  level: z.enum(['local', 'regional', 'state', 'federal']).optional(),
 })
+
+export type VoterIssueLevel = z.infer<typeof getVoterIssuesQuerySchema>['level']
 
 export class GetVoterIssuesQueryDTO extends createZodDto(
   getVoterIssuesQuerySchema,

--- a/src/voterIssues/voterIssues.service.test.ts
+++ b/src/voterIssues/voterIssues.service.test.ts
@@ -16,9 +16,7 @@ describe('VoterIssuesService', () => {
   })
 
   it('queries DistrictTopIssue with the given districtId, ordered by issueRank, capped by limit', async () => {
-    findMany.mockResolvedValue([
-      { issueLabel: 'Education', score: 88, issueRank: 1 },
-    ])
+    findMany.mockResolvedValue([{ issueLabel: 'Education', score: 88 }])
 
     const result = await service.getVoterIssues({
       districtId: 'd-1',
@@ -29,20 +27,26 @@ describe('VoterIssuesService', () => {
       where: { districtId: 'd-1' },
       orderBy: { issueRank: 'asc' },
       take: 5,
-      select: { issueLabel: true, score: true, issueRank: true },
+      select: { issueLabel: true, score: true },
     })
     expect(result).toEqual([
       { label: 'Education', score: 88, priority: 'high' },
     ])
   })
 
-  it('maps issueLabel to label and assigns priority by rank boundary', async () => {
+  it('assigns priority by position-in-result, not by precomputed issueRank', async () => {
+    // Mock with non-contiguous "ranks" implied by ordering; the service no
+    // longer reads issueRank from the row. Position 1-3 -> high, 4-6 ->
+    // medium, 7+ -> low. This matters for filtered queries where the
+    // overall ranks of returned rows are typically much higher than 3.
     findMany.mockResolvedValue([
-      { issueLabel: 'A', score: 90, issueRank: 1 },
-      { issueLabel: 'B', score: 80, issueRank: 3 },
-      { issueLabel: 'C', score: 70, issueRank: 4 },
-      { issueLabel: 'D', score: 60, issueRank: 6 },
-      { issueLabel: 'E', score: 50, issueRank: 7 },
+      { issueLabel: 'A', score: 90 },
+      { issueLabel: 'B', score: 85 },
+      { issueLabel: 'C', score: 80 },
+      { issueLabel: 'D', score: 75 },
+      { issueLabel: 'E', score: 70 },
+      { issueLabel: 'F', score: 65 },
+      { issueLabel: 'G', score: 60 },
     ])
 
     const result = await service.getVoterIssues({
@@ -52,10 +56,12 @@ describe('VoterIssuesService', () => {
 
     expect(result).toEqual([
       { label: 'A', score: 90, priority: 'high' },
-      { label: 'B', score: 80, priority: 'high' },
-      { label: 'C', score: 70, priority: 'medium' },
-      { label: 'D', score: 60, priority: 'medium' },
-      { label: 'E', score: 50, priority: 'low' },
+      { label: 'B', score: 85, priority: 'high' },
+      { label: 'C', score: 80, priority: 'high' },
+      { label: 'D', score: 75, priority: 'medium' },
+      { label: 'E', score: 70, priority: 'medium' },
+      { label: 'F', score: 65, priority: 'medium' },
+      { label: 'G', score: 60, priority: 'low' },
     ])
   })
 
@@ -80,9 +86,9 @@ describe('VoterIssuesService', () => {
 
   it('preserves DB order (issueRank asc) in the output', async () => {
     findMany.mockResolvedValue([
-      { issueLabel: 'First', score: 95, issueRank: 1 },
-      { issueLabel: 'Second', score: 70, issueRank: 2 },
-      { issueLabel: 'Third', score: 40, issueRank: 5 },
+      { issueLabel: 'First', score: 95 },
+      { issueLabel: 'Second', score: 70 },
+      { issueLabel: 'Third', score: 40 },
     ])
 
     const result = await service.getVoterIssues({
@@ -91,5 +97,41 @@ describe('VoterIssuesService', () => {
     })
 
     expect(result.map((r) => r.label)).toEqual(['First', 'Second', 'Third'])
+  })
+
+  it.each([
+    ['local', 'isLocal'] as const,
+    ['regional', 'isRegional'] as const,
+    ['state', 'isState'] as const,
+    ['federal', 'isFederal'] as const,
+  ])(
+    'adds the %s jurisdictional flag to the where clause when level=%s',
+    async (level, flagColumn) => {
+      findMany.mockResolvedValue([])
+
+      await service.getVoterIssues({
+        districtId: 'd-1',
+        limit: 10,
+        level,
+      })
+
+      expect(findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { districtId: 'd-1', [flagColumn]: true },
+        }),
+      )
+    },
+  )
+
+  it('applies no jurisdictional filter when level is undefined', async () => {
+    findMany.mockResolvedValue([])
+
+    await service.getVoterIssues({ districtId: 'd-1', limit: 10 })
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { districtId: 'd-1' },
+      }),
+    )
   })
 })

--- a/src/voterIssues/voterIssues.service.ts
+++ b/src/voterIssues/voterIssues.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
-import { VoterIssue } from './voterIssues.schema'
+import { VoterIssue, VoterIssueLevel } from './voterIssues.schema'
 
 @Injectable()
 export class VoterIssuesService extends createPrismaBase(
@@ -13,18 +13,42 @@ export class VoterIssuesService extends createPrismaBase(
   async getVoterIssues(params: {
     districtId: string
     limit: number
+    level?: VoterIssueLevel
   }): Promise<VoterIssue[]> {
+    // Filter by jurisdictional flag when `level` is provided so each persona
+    // (school-board candidate, US House candidate, etc.) only sees issues
+    // actionable at their office level. Without `level`, returns the overall
+    // top issues by score across all 68 issues.
+    const where: {
+      districtId: string
+      isLocal?: boolean
+      isRegional?: boolean
+      isState?: boolean
+      isFederal?: boolean
+    } = { districtId: params.districtId }
+    if (params.level === 'local') where.isLocal = true
+    else if (params.level === 'regional') where.isRegional = true
+    else if (params.level === 'state') where.isState = true
+    else if (params.level === 'federal') where.isFederal = true
+
     const rows = await this.model.findMany({
-      where: { districtId: params.districtId },
+      where,
       orderBy: { issueRank: 'asc' },
       take: params.limit,
-      select: { issueLabel: true, score: true, issueRank: true },
+      select: { issueLabel: true, score: true },
     })
 
-    return rows.map((row) => ({
+    // Priority is position-in-result, not the mart's precomputed issue_rank.
+    // For the unfiltered case the two are identical (sorted-by-rank asc
+    // produces positions 1..N matching ranks 1..N). For filtered queries the
+    // top issue in the filter is always "high", even if its overall mart rank
+    // is much higher than 3 — without this remapping, every local-only issue
+    // would land in the "low" tier because federal noise dominates the top
+    // overall ranks.
+    return rows.map((row, index) => ({
       label: row.issueLabel,
       score: row.score,
-      priority: this.priorityForRank(row.issueRank),
+      priority: this.priorityForRank(index + 1),
     }))
   }
 


### PR DESCRIPTION
## Summary
Two commits paired together as the election-api side of the local-issue-filter feature (companion to thegoodparty/gp-data-platform#390, merged):

1. **`5b4b0e5`** — Prisma migration adding four nullable boolean columns (`is_local`, `is_regional`, `is_state`, `is_federal`) to `DistrictTopIssue`.
2. **`f43a3a4`** — `voterIssues.service` and `voterIssues.schema` updated so the `/voter-issues` endpoint accepts an optional `level` query parameter and filters by the matching jurisdictional flag.

Pairing them in one PR (originally planned as two) eliminates an in-between deploy window where the columns would exist as NULL but no API behavior would use them yet.

## Why
Today's candidate onboarding flow surfaces federal-only issues like "Border Wall" and "Ukraine policy" to school-board candidates' top-issues lists. With this PR + gp-data-platform#391 deployed, the candidate UI can pass `?level=local` (or `state`/`regional`/`federal`) to scope the result to issues actionable at their office level.

Product calls coordinated with Sanjay over Slack:
- Query parameter name: `level`.
- Default behavior: when `level` is absent, return overall top issues by score (current behavior).
- `priorityForRank()` switches to position-in-result so the top filtered issue is always "high" priority. For the unfiltered case this is identical to the current rank-based mapping (positions 1..N match ranks 1..N).

## Shape
- The four flag columns are `Boolean?` (nullable, no default) intentionally — keeps the nightly `sync_election_api` Airflow run working unchanged while the columns are unpopulated, and lets the API treat NULL as "unknown" gracefully.
- Tightening to `Boolean NOT NULL DEFAULT FALSE` is a separate optional decision once data is flowing end-to-end (truly optional; out of scope here).

## Files changed
- `prisma/schema/districtTopIssue.prisma` — four new fields, alignment formatting via `prisma format`.
- `prisma/migrations/20260513035356_add_district_top_issue_jurisdiction_flags/migration.sql` — single `ALTER TABLE` adding the four BOOLEAN columns.
- `src/voterIssues/voterIssues.schema.ts` — `level` enum added to the Zod query schema; `VoterIssueLevel` type exported.
- `src/voterIssues/voterIssues.service.ts` — conditional `where` clause based on `level`; priority switched to position-in-result.
- `src/voterIssues/voterIssues.controller.ts` — forwards `level` to the service when provided.
- `src/voterIssues/voterIssues.service.test.ts` and `voterIssues.controller.test.ts` — existing test coverage updated, six new test cases added.

## Test plan
- [x] `vitest run src/voterIssues` — all 12 tests pass locally (was 6, expanded with filter coverage).
- [ ] CI passes.
- [ ] After merge: migration applies cleanly in dev.
- [ ] After gp-data-platform#391 merges and the next `sync_election_api` Airflow run completes: verify in dev that the four columns are populated for every row (`SELECT COUNT(*) FILTER (WHERE is_local IS NULL), COUNT(*) FROM "DistrictTopIssue"` should show 0 unfilled).
- [ ] After dev validation: hit the dev API with `?districtId=<uuid>&level=local` and confirm the response (a) returns only local-flagged issues, (b) starts with priority="high" on the top row.

## Cross-repo references
- Companion: thegoodparty/gp-data-platform#390 — merged. The dbt mart producing the flag values.
- Companion: thegoodparty/gp-data-platform#391 — open, gated on this PR landing in prod. It drops the temporary Airflow legacy-issue filter and extends `DTI_COLUMNS` to populate the four columns in Postgres.
- Design doc: `.tickets/data-1903/04-design.md` in gp-data-platform (especially §11 ship sequence and §14 column contract).