### PR TITLE
feat(positions): expose BallotReady filing fees on position endpoint

### DIFF
--- a/src/positions/positions.controller.ts
+++ b/src/positions/positions.controller.ts
@@ -16,12 +16,14 @@ export class PositionsController {
     @Param() params: GetPositionByBrIdParamsDTO,
     @Query() query: GetPositionByBrIdQueryDTO,
   ): Promise<PositionWithOptionalDistrict> {
-    const { includeDistrict, electionDate, includeTurnout } = query
+    const { includeDistrict, electionDate, includeTurnout, includeFilingFee } =
+      query
     return this.positions.getPositionByBallotReadyId({
       brPositionId: params.brPositionId,
       includeDistrict: includeDistrict,
       electionDate: electionDate,
       includeTurnout: includeTurnout,
+      includeFilingFee: includeFilingFee,
     })
   }
 
@@ -30,12 +32,14 @@ export class PositionsController {
     @Param() params: GetPositionByIdParamsDTO,
     @Query() query: GetPositionByBrIdQueryDTO,
   ): Promise<PositionWithOptionalDistrict> {
-    const { includeDistrict, electionDate, includeTurnout } = query
+    const { includeDistrict, electionDate, includeTurnout, includeFilingFee } =
+      query
     return this.positions.getPositionById({
       id: params.id,
       includeDistrict: includeDistrict,
       electionDate: electionDate,
       includeTurnout: includeTurnout,
+      includeFilingFee: includeFilingFee,
     })
   }
 }

--- a/src/positions/positions.schema.ts
+++ b/src/positions/positions.schema.ts
@@ -25,6 +25,15 @@ export const getPositionByBrIdQuerySchema = z
       z.boolean().optional().default(false),
     ),
     includeDistrict: z.coerce.boolean().optional(),
+    includeFilingFee: z.preprocess(
+      (val) =>
+        val === 'true' || val === '1' || val === true
+          ? true
+          : val === 'false' || val === '0' || val === false
+            ? false
+            : undefined,
+      z.boolean().optional().default(false),
+    ),
     electionDate: z
       .string()
       .optional()

--- a/src/positions/positions.service.test.ts
+++ b/src/positions/positions.service.test.ts
@@ -11,6 +11,7 @@ import { PositionsService } from './positions.service'
 describe('PositionsService', () => {
   let service: PositionsService
   let findUnique: ReturnType<typeof vi.fn>
+  let raceFindMany: ReturnType<typeof vi.fn>
   let projectedTurnoutService: Pick<
     ProjectedTurnoutService,
     'determineElectionCode'
@@ -18,6 +19,7 @@ describe('PositionsService', () => {
 
   beforeEach(() => {
     findUnique = vi.fn()
+    raceFindMany = vi.fn()
     projectedTurnoutService = {
       determineElectionCode: vi.fn(),
     }
@@ -28,6 +30,9 @@ describe('PositionsService', () => {
       value: {
         position: {
           findUnique,
+        },
+        race: {
+          findMany: raceFindMany,
         },
       },
     })
@@ -83,6 +88,7 @@ describe('PositionsService', () => {
         state: true,
         name: true,
         level: true,
+        placeId: true,
       },
     })
     expect(result).toEqual({
@@ -365,5 +371,247 @@ describe('PositionsService', () => {
     ).rejects.toThrow(
       new NotFoundException('Position not found for brPositionId=missing-id'),
     )
+  })
+
+  describe('includeFilingFee', () => {
+    const positionRow = {
+      id: 'pos-1',
+      brPositionId: 'br-pos-1',
+      brDatabaseId: 'db-1',
+      state: 'CA',
+      name: 'Mayor',
+      placeId: 'place-1',
+    }
+
+    it('does not query Race when includeFilingFee is false', async () => {
+      findUnique.mockResolvedValue(positionRow)
+
+      const result = await service.getPositionById({
+        id: 'pos-1',
+        includeFilingFee: false,
+      })
+
+      expect(raceFindMany).not.toHaveBeenCalled()
+      expect(result.filingFee).toBeUndefined()
+      expect(result.filingRequirementsText).toBeUndefined()
+    })
+
+    it('returns null filing fee when position has no placeId', async () => {
+      findUnique.mockResolvedValue({ ...positionRow, placeId: null })
+
+      const result = await service.getPositionById({
+        id: 'pos-1',
+        includeFilingFee: true,
+      })
+
+      expect(raceFindMany).not.toHaveBeenCalled()
+      expect(result.filingFee).toBeNull()
+      expect(result.filingRequirementsText).toBeNull()
+      expect(result.filingFeeExtractionSource).toBeNull()
+    })
+
+    it('returns null filing fee when no Race matches placeId + name', async () => {
+      findUnique.mockResolvedValue(positionRow)
+      raceFindMany.mockResolvedValue([])
+
+      const result = await service.getPositionById({
+        id: 'pos-1',
+        includeFilingFee: true,
+      })
+
+      expect(raceFindMany).toHaveBeenCalledWith({
+        where: {
+          placeId: 'place-1',
+          positionNames: { has: 'Mayor' },
+        },
+        select: {
+          electionDate: true,
+          isPrimary: true,
+          isRunoff: true,
+          filingRequirements: true,
+          salary: true,
+        },
+      })
+      expect(result.filingFee).toBeNull()
+      expect(result.filingRequirementsText).toBeNull()
+      expect(result.filingFeeExtractionSource).toBeNull()
+    })
+
+    it('extracts the filing fee from the matching Race row', async () => {
+      findUnique.mockResolvedValue(positionRow)
+      raceFindMany.mockResolvedValue([
+        {
+          electionDate: new Date('2030-11-05'),
+          isPrimary: false,
+          isRunoff: false,
+          filingRequirements: 'Filing fee is $250.',
+          salary: null,
+        },
+      ])
+
+      const result = await service.getPositionById({
+        id: 'pos-1',
+        includeFilingFee: true,
+      })
+
+      expect(result.filingFee).toBe(250)
+      expect(result.filingRequirementsText).toBe('Filing fee is $250.')
+      expect(result.filingFeeExtractionSource).toBe('direct_dollar')
+    })
+
+    it('prefers the race matching the given electionDate exactly', async () => {
+      findUnique.mockResolvedValue(positionRow)
+      raceFindMany.mockResolvedValue([
+        {
+          electionDate: new Date('2024-11-05'),
+          isPrimary: false,
+          isRunoff: false,
+          filingRequirements: '$500 fee',
+          salary: null,
+        },
+        {
+          electionDate: new Date('2028-11-07'),
+          isPrimary: false,
+          isRunoff: false,
+          filingRequirements: '$1,000 fee',
+          salary: null,
+        },
+      ])
+
+      const result = await service.getPositionById({
+        id: 'pos-1',
+        includeFilingFee: true,
+        electionDate: '2028-11-07',
+      })
+
+      expect(result.filingFee).toBe(1000)
+    })
+
+    it('nulls out fee but keeps raw text when race has multiple dollar amounts', async () => {
+      findUnique.mockResolvedValue(positionRow)
+      raceFindMany.mockResolvedValue([
+        {
+          electionDate: new Date('2030-11-05'),
+          isPrimary: false,
+          isRunoff: false,
+          filingRequirements: '$300 for D/R candidates, $50 for independents.',
+          salary: null,
+        },
+      ])
+
+      const result = await service.getPositionById({
+        id: 'pos-1',
+        includeFilingFee: true,
+      })
+
+      expect(result.filingFee).toBeNull()
+      expect(result.filingRequirementsText).toBe(
+        '$300 for D/R candidates, $50 for independents.',
+      )
+      expect(result.filingFeeExtractionSource).toBe('multi_value')
+    })
+
+    it('computes pct_of_salary end-to-end through the service', async () => {
+      findUnique.mockResolvedValue(positionRow)
+      raceFindMany.mockResolvedValue([
+        {
+          electionDate: new Date('2030-11-05'),
+          isPrimary: false,
+          isRunoff: false,
+          filingRequirements: 'Filing fee is 2% of annual salary.',
+          salary: '$80,000 per year',
+        },
+      ])
+
+      const result = await service.getPositionById({
+        id: 'pos-1',
+        includeFilingFee: true,
+      })
+
+      expect(result.filingFee).toBe(1600)
+      expect(result.filingFeeExtractionSource).toBe('pct_of_salary')
+    })
+
+    it('attaches filing fee fields to the includeDistrict response shape', async () => {
+      findUnique.mockResolvedValue({
+        ...positionRow,
+        district: {
+          id: 'district-1',
+          L2DistrictType: 'City',
+          L2DistrictName: 'Los Angeles',
+        },
+      })
+      raceFindMany.mockResolvedValue([
+        {
+          electionDate: new Date('2030-11-05'),
+          isPrimary: false,
+          isRunoff: false,
+          filingRequirements: 'Filing fee is $125.',
+          salary: null,
+        },
+      ])
+
+      const result = await service.getPositionById({
+        id: 'pos-1',
+        includeDistrict: true,
+        includeFilingFee: true,
+      })
+
+      expect(result.district).toEqual({
+        id: 'district-1',
+        L2DistrictType: 'City',
+        L2DistrictName: 'Los Angeles',
+        projectedTurnout: null,
+      })
+      expect(result.filingFee).toBe(125)
+      expect(result.filingRequirementsText).toBe('Filing fee is $125.')
+      expect(result.filingFeeExtractionSource).toBe('direct_dollar')
+    })
+
+    it('attaches filing fee fields to the includeTurnout response shape', async () => {
+      vi.mocked(projectedTurnoutService.determineElectionCode).mockReturnValue(
+        ElectionCode.General,
+      )
+      findUnique.mockResolvedValue({
+        ...positionRow,
+        district: {
+          id: 'district-1',
+          L2DistrictType: 'City',
+          L2DistrictName: 'Los Angeles',
+          ProjectedTurnouts: [
+            {
+              id: 'pt-1',
+              electionYear: 2030,
+              electionCode: ElectionCode.General,
+            },
+          ],
+        },
+      })
+      raceFindMany.mockResolvedValue([
+        {
+          electionDate: new Date('2030-11-05'),
+          isPrimary: false,
+          isRunoff: false,
+          filingRequirements: 'Filing fee is $75.',
+          salary: null,
+        },
+      ])
+
+      const result = await service.getPositionById({
+        id: 'pos-1',
+        includeDistrict: true,
+        includeTurnout: true,
+        includeFilingFee: true,
+        electionDate: '2030-11-05',
+      })
+
+      expect(result.district?.projectedTurnout).toMatchObject({
+        id: 'pt-1',
+        electionYear: 2030,
+        electionCode: ElectionCode.General,
+      })
+      expect(result.filingFee).toBe(75)
+      expect(result.filingFeeExtractionSource).toBe('direct_dollar')
+    })
   })
 })

--- a/src/positions/positions.service.test.ts
+++ b/src/positions/positions.service.test.ts
@@ -88,7 +88,6 @@ describe('PositionsService', () => {
         state: true,
         name: true,
         level: true,
-        placeId: true,
       },
     })
     expect(result).toEqual({
@@ -394,6 +393,35 @@ describe('PositionsService', () => {
       expect(raceFindMany).not.toHaveBeenCalled()
       expect(result.filingFee).toBeUndefined()
       expect(result.filingRequirementsText).toBeUndefined()
+    })
+
+    it('does not fetch placeId on findUnique when includeFilingFee is false', async () => {
+      findUnique.mockResolvedValue(positionRow)
+
+      await service.getPositionById({
+        id: 'pos-1',
+        includeFilingFee: false,
+      })
+
+      expect(findUnique).toHaveBeenCalledWith({
+        where: { id: 'pos-1' },
+        select: expect.not.objectContaining({ placeId: true }),
+      })
+    })
+
+    it('fetches placeId on findUnique when includeFilingFee is true', async () => {
+      findUnique.mockResolvedValue(positionRow)
+      raceFindMany.mockResolvedValue([])
+
+      await service.getPositionById({
+        id: 'pos-1',
+        includeFilingFee: true,
+      })
+
+      expect(findUnique).toHaveBeenCalledWith({
+        where: { id: 'pos-1' },
+        select: expect.objectContaining({ placeId: true }),
+      })
     })
 
     it('returns null filing fee when position has no placeId', async () => {

--- a/src/positions/positions.service.ts
+++ b/src/positions/positions.service.ts
@@ -107,15 +107,15 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
     } = params
     this.validateOptions({ includeDistrict, includeTurnout, electionDate })
 
-    const baseSelect = {
+    const baseSelect: Prisma.PositionSelect = {
       id: true,
       brPositionId: true,
       brDatabaseId: true,
       state: true,
       name: true,
       level: true,
-      placeId: true,
-    } satisfies Prisma.PositionSelect
+      ...(includeFilingFee ? { placeId: true } : {}),
+    }
 
     if (!includeDistrict) {
       const position: PositionWithOptionalDistrictAndTurnouts | null =

--- a/src/positions/positions.service.ts
+++ b/src/positions/positions.service.ts
@@ -8,10 +8,13 @@ import { District, Position, Prisma, ProjectedTurnout } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { ProjectedTurnoutService } from 'src/projectedTurnout/projectedTurnout.service'
 import { PositionWithOptionalDistrict } from './positions.types'
+import { extractFilingFee, FilingFeeResult } from './util/filingFee.util'
+import { pickRelevantRace } from './util/pickRelevantRace.util'
 
 type PositionLookupOptions = {
   includeDistrict?: boolean
   includeTurnout?: boolean
+  includeFilingFee?: boolean
   electionDate?: string
 }
 
@@ -27,6 +30,7 @@ type PositionWithOptionalDistrictAndTurnouts = {
   state: Position['state']
   name: Position['name']
   level: Position['level']
+  placeId?: Position['placeId'] | null
   district?: {
     id: District['id']
     L2DistrictType: District['L2DistrictType']
@@ -47,6 +51,7 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
     id: string
     includeDistrict?: boolean
     includeTurnout?: boolean
+    includeFilingFee?: boolean
     electionDate?: string
   }): Promise<PositionWithOptionalDistrict> {
     const { id } = params
@@ -61,6 +66,7 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
     brPositionId: string
     includeDistrict?: boolean
     includeTurnout?: boolean
+    includeFilingFee?: boolean
     electionDate?: string
   }): Promise<PositionWithOptionalDistrict> {
     const { brPositionId } = params
@@ -96,31 +102,34 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
       notFoundMessage,
       includeDistrict,
       includeTurnout,
+      includeFilingFee,
       electionDate,
     } = params
     this.validateOptions({ includeDistrict, includeTurnout, electionDate })
 
+    const baseSelect = {
+      id: true,
+      brPositionId: true,
+      brDatabaseId: true,
+      state: true,
+      name: true,
+      level: true,
+      placeId: true,
+    } satisfies Prisma.PositionSelect
+
     if (!includeDistrict) {
       const position: PositionWithOptionalDistrictAndTurnouts | null =
-        await this.model.findUnique({
-          where,
-          select: {
-            id: true,
-            brPositionId: true,
-            brDatabaseId: true,
-            state: true,
-            name: true,
-            level: true,
-          },
-        })
+        await this.model.findUnique({ where, select: baseSelect })
       if (!position) {
         throw new NotFoundException(notFoundMessage)
       }
-      return this.shapePositionResponse(position)
+      const filingFee = includeFilingFee
+        ? await this.lookupFilingFee(position, electionDate)
+        : undefined
+      return this.shapePositionResponse(position, undefined, filingFee)
     }
 
     if (!includeTurnout) {
-      // If the caller doesn't want projectedTurnout, no further processing is needed
       const position: PositionWithOptionalDistrictAndTurnouts | null =
         await this.model.findUnique({
           where,
@@ -129,7 +138,10 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
       if (!position) {
         throw new NotFoundException(notFoundMessage)
       }
-      return this.shapePositionResponse(position)
+      const filingFee = includeFilingFee
+        ? await this.lookupFilingFee(position, electionDate)
+        : undefined
+      return this.shapePositionResponse(position, undefined, filingFee)
     }
 
     const position: PositionWithOptionalDistrictAndTurnouts | null =
@@ -151,17 +163,40 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
         'It should be impossible to get to this line without electionDate defined',
       )
     }
-    return this.shapePositionResponse(position, electionDate)
+    const filingFee = includeFilingFee
+      ? await this.lookupFilingFee(position, electionDate)
+      : undefined
+    return this.shapePositionResponse(position, electionDate, filingFee)
   }
 
   private shapePositionResponse(
     position: PositionWithOptionalDistrictAndTurnouts,
     electionDate?: string,
+    filingFee?: FilingFeeResult,
   ): PositionWithOptionalDistrict {
     const { id, brPositionId, brDatabaseId, state, level, name, district } =
       position
+    const filingFeeFields: Pick<
+      PositionWithOptionalDistrict,
+      'filingFee' | 'filingRequirementsText' | 'filingFeeExtractionSource'
+    > = filingFee
+      ? {
+          filingFee: filingFee.filingFee,
+          filingRequirementsText: filingFee.filingRequirementsText,
+          filingFeeExtractionSource: filingFee.extractionSource,
+        }
+      : {}
+
     if (!district) {
-      return { id, brPositionId, brDatabaseId, state, name, level }
+      return {
+        id,
+        brPositionId,
+        brDatabaseId,
+        state,
+        name,
+        level,
+        ...filingFeeFields,
+      }
     }
 
     const {
@@ -186,6 +221,7 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
         name,
         district: districtResponse,
         level,
+        ...filingFeeFields,
       }
     }
 
@@ -217,6 +253,48 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
         ...districtResponse,
         projectedTurnout: projectedTurnout ?? null,
       },
+      ...filingFeeFields,
     }
+  }
+
+  /**
+   * BallotReady stores filing fees on the Race row, not the Position. There's
+   * no FK between Position and Race — the de-facto join is shared `placeId`
+   * plus a position-name match against Race.positionNames. One Position can
+   * have many Races (different election dates, primary vs. general), so we
+   * pick the most relevant one: matching electionDate exact > nearest future
+   * general > nearest future > latest historical. Returns an empty result if
+   * no candidate race exists or its filingRequirements yields nothing.
+   */
+  private async lookupFilingFee(
+    position: PositionWithOptionalDistrictAndTurnouts,
+    electionDate?: string,
+  ): Promise<FilingFeeResult> {
+    const empty: FilingFeeResult = {
+      filingFee: null,
+      filingRequirementsText: null,
+      extractionSource: null,
+    }
+    if (!position.placeId || !position.name) return empty
+
+    const races = await this.client.race.findMany({
+      where: {
+        placeId: position.placeId,
+        positionNames: { has: position.name },
+      },
+      select: {
+        electionDate: true,
+        isPrimary: true,
+        isRunoff: true,
+        filingRequirements: true,
+        salary: true,
+      },
+    })
+    if (races.length === 0) return empty
+
+    const chosen = pickRelevantRace(races, electionDate)
+    if (!chosen) return empty
+
+    return extractFilingFee(chosen.filingRequirements, chosen.salary)
   }
 }

--- a/src/positions/positions.types.ts
+++ b/src/positions/positions.types.ts
@@ -1,4 +1,5 @@
 import { Position, ProjectedTurnout } from '@prisma/client'
+import type { FilingFeeExtractionSource } from './util/filingFee.util'
 
 export type PositionWithOptionalDistrict = Pick<
   Position,
@@ -12,4 +13,7 @@ export type PositionWithOptionalDistrict = Pick<
     L2DistrictName: string
     projectedTurnout: ProjectedTurnout | null
   }
+  filingFee?: number | null
+  filingRequirementsText?: string | null
+  filingFeeExtractionSource?: FilingFeeExtractionSource | null
 }

--- a/src/positions/util/filingFee.util.test.ts
+++ b/src/positions/util/filingFee.util.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { extractFilingFee } from './filingFee.util'
+
+describe('extractFilingFee', () => {
+  it('returns empty result when filingRequirements is null', () => {
+    expect(extractFilingFee(null, '$100,000')).toEqual({
+      filingFee: null,
+      filingRequirementsText: null,
+      extractionSource: null,
+    })
+  })
+
+  it('returns empty result when filingRequirements is an empty string', () => {
+    expect(extractFilingFee('', '$100,000')).toEqual({
+      filingFee: null,
+      filingRequirementsText: null,
+      extractionSource: null,
+    })
+  })
+
+  it('extracts a single dollar amount with commas', () => {
+    const result = extractFilingFee('Filing fee is $1,250.00.', null)
+    expect(result).toEqual({
+      filingFee: 1250,
+      filingRequirementsText: 'Filing fee is $1,250.00.',
+      extractionSource: 'direct_dollar',
+    })
+  })
+
+  it('extracts a single dollar amount without commas', () => {
+    const result = extractFilingFee('A $50 fee is due at filing.', null)
+    expect(result.filingFee).toBe(50)
+    expect(result.extractionSource).toBe('direct_dollar')
+  })
+
+  it('returns multi_value when multiple dollar amounts are present', () => {
+    const result = extractFilingFee(
+      'Filing fee: $300 for D/R candidates, $50 for independents.',
+      null,
+    )
+    expect(result).toEqual({
+      filingFee: null,
+      filingRequirementsText:
+        'Filing fee: $300 for D/R candidates, $50 for independents.',
+      extractionSource: 'multi_value',
+    })
+  })
+
+  it('recognizes "no filing fee" copy as $0', () => {
+    const result = extractFilingFee(
+      'There is no filing fee for this office.',
+      null,
+    )
+    expect(result.filingFee).toBe(0)
+    expect(result.extractionSource).toBe('no_fee')
+  })
+
+  it('recognizes "no fee" copy case-insensitively', () => {
+    const result = extractFilingFee('NO FEE required.', null)
+    expect(result.filingFee).toBe(0)
+    expect(result.extractionSource).toBe('no_fee')
+  })
+
+  it('computes percent of salary when salary contains a dollar amount', () => {
+    const result = extractFilingFee(
+      'Filing requires 2% of the annual salary.',
+      '$60,000 per year',
+    )
+    expect(result.filingFee).toBe(1200)
+    expect(result.extractionSource).toBe('pct_of_salary')
+  })
+
+  it('returns pct_of_salary_unresolvable when salary cannot be parsed', () => {
+    const result = extractFilingFee(
+      'Filing requires 1% of the annual salary.',
+      'Varies by district',
+    )
+    expect(result.filingFee).toBeNull()
+    expect(result.extractionSource).toBe('pct_of_salary_unresolvable')
+  })
+
+  it('falls through to no_match when no pattern fits', () => {
+    const result = extractFilingFee('See the county clerk for details.', null)
+    expect(result.filingFee).toBeNull()
+    expect(result.extractionSource).toBe('no_match')
+  })
+
+  it('always preserves the raw filingRequirements text', () => {
+    const inputs = [
+      'Filing fee is $1,250.00.',
+      'See the county clerk for details.',
+      'Filing fee: $300 for D/R, $50 for independents.',
+      'no filing fee',
+    ]
+    for (const input of inputs) {
+      expect(extractFilingFee(input, null).filingRequirementsText).toBe(input)
+    }
+  })
+})

--- a/src/positions/util/filingFee.util.ts
+++ b/src/positions/util/filingFee.util.ts
@@ -1,0 +1,113 @@
+/**
+ * Extracts the filing fee for a race from BallotReady's free-text
+ * `filing_requirements` column. Mirrors the dbt staging query the data team
+ * uses against `stg_airbyte_source__ballotready_s3_recruitment_v1`, but with
+ * one pragmatic deviation: rows containing multiple dollar amounts are nulled
+ * out (returned as `multi_value`) instead of picking the first one. Per the
+ * data team, ~8% of rows fall here — typically separate fees per party — and
+ * the first-match heuristic silently lies. Returning null with the raw text
+ * lets the UI render a "fee varies — see BallotReady" affordance instead.
+ *
+ * The raw `filingRequirements` text is ALWAYS passed through, even when no
+ * fee was extracted, so downstream callers can always show "click for full
+ * text from BallotReady."
+ */
+
+export type FilingFeeExtractionSource =
+  | 'direct_dollar'
+  | 'no_fee'
+  | 'pct_of_salary'
+  | 'pct_of_salary_unresolvable'
+  | 'multi_value'
+  | 'no_match'
+
+export interface FilingFeeResult {
+  filingFee: number | null
+  filingRequirementsText: string | null
+  extractionSource: FilingFeeExtractionSource | null
+}
+
+const DOLLAR_PATTERN = /\$([0-9]+(?:,[0-9]{3})*(?:\.[0-9]+)?)/g
+const NO_FEE_PATTERN = /no filing fee|no fee/i
+const PCT_OF_SALARY_PATTERN =
+  /([0-9]+(?:\.[0-9]+)?)\s*(?:%|percent)[^.;]*?salary/i
+
+const parseDollarString = (raw: string): number =>
+  Number(raw.replace(/,/g, ''))
+
+const EMPTY_RESULT: FilingFeeResult = {
+  filingFee: null,
+  filingRequirementsText: null,
+  extractionSource: null,
+}
+
+export const extractFilingFee = (
+  filingRequirements: string | null | undefined,
+  salary: string | null | undefined,
+): FilingFeeResult => {
+  if (!filingRequirements || filingRequirements.trim() === '') {
+    return EMPTY_RESULT
+  }
+
+  const filingRequirementsText = filingRequirements
+
+  const dollarMatches = Array.from(filingRequirements.matchAll(DOLLAR_PATTERN))
+
+  if (dollarMatches.length > 1) {
+    return {
+      filingFee: null,
+      filingRequirementsText,
+      extractionSource: 'multi_value',
+    }
+  }
+
+  if (dollarMatches.length === 1) {
+    const raw = dollarMatches[0]?.[1] ?? ''
+    const value = parseDollarString(raw)
+    if (Number.isFinite(value)) {
+      return {
+        filingFee: value,
+        filingRequirementsText,
+        extractionSource: 'direct_dollar',
+      }
+    }
+  }
+
+  if (NO_FEE_PATTERN.test(filingRequirements)) {
+    return {
+      filingFee: 0,
+      filingRequirementsText,
+      extractionSource: 'no_fee',
+    }
+  }
+
+  const pctMatch = PCT_OF_SALARY_PATTERN.exec(filingRequirements)
+  if (pctMatch) {
+    const pct = Number(pctMatch[1])
+    const salaryDollarMatch = salary
+      ? new RegExp(DOLLAR_PATTERN.source).exec(salary)
+      : null
+    if (salaryDollarMatch && Number.isFinite(pct)) {
+      const salaryDollars = parseDollarString(salaryDollarMatch[1] ?? '')
+      if (Number.isFinite(salaryDollars)) {
+        const fee = (pct / 100) * salaryDollars
+        return {
+          filingFee: Math.round(fee * 100) / 100,
+          filingRequirementsText,
+          extractionSource: 'pct_of_salary',
+        }
+      }
+    }
+    return {
+      filingFee: null,
+      filingRequirementsText,
+      extractionSource: 'pct_of_salary_unresolvable',
+    }
+  }
+
+  return {
+    filingFee: null,
+    filingRequirementsText,
+    extractionSource: 'no_match',
+  }
+}

--- a/src/positions/util/pickRelevantRace.util.test.ts
+++ b/src/positions/util/pickRelevantRace.util.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, beforeAll, afterAll, vi } from 'vitest'
+import { pickRelevantRace, RaceForFilingFee } from './pickRelevantRace.util'
+
+const NOW = new Date('2026-06-01T00:00:00Z').getTime()
+
+const makeRace = (overrides: Partial<RaceForFilingFee>): RaceForFilingFee => ({
+  electionDate: new Date('2030-11-05'),
+  isPrimary: false,
+  isRunoff: false,
+  filingRequirements: null,
+  salary: null,
+  ...overrides,
+})
+
+beforeAll(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(NOW))
+})
+
+afterAll(() => {
+  vi.useRealTimers()
+})
+
+describe('pickRelevantRace', () => {
+  it('returns null for an empty list', () => {
+    expect(pickRelevantRace([])).toBeNull()
+  })
+
+  it('returns null for an empty list even with an electionDate', () => {
+    expect(pickRelevantRace([], '2026-11-03')).toBeNull()
+  })
+
+  it('returns the exact electionDate match when provided', () => {
+    const races = [
+      makeRace({ electionDate: new Date('2026-11-03') }),
+      makeRace({ electionDate: new Date('2028-11-07') }),
+      makeRace({ electionDate: new Date('2030-11-05') }),
+    ]
+    const chosen = pickRelevantRace(races, '2028-11-07')
+    expect(chosen?.electionDate.toISOString()).toBe(
+      new Date('2028-11-07').toISOString(),
+    )
+  })
+
+  it('falls through to general-future when electionDate match is missing', () => {
+    const races = [
+      makeRace({ electionDate: new Date('2027-03-15'), isPrimary: true }),
+      makeRace({ electionDate: new Date('2027-11-02') }),
+    ]
+    const chosen = pickRelevantRace(races, '2099-12-31')
+    expect(chosen?.electionDate.toISOString()).toBe(
+      new Date('2027-11-02').toISOString(),
+    )
+  })
+
+  it('prefers general elections over primaries', () => {
+    const races = [
+      makeRace({ electionDate: new Date('2027-03-15'), isPrimary: true }),
+      makeRace({ electionDate: new Date('2027-11-02') }),
+    ]
+    const chosen = pickRelevantRace(races)
+    expect(chosen?.isPrimary).toBe(false)
+  })
+
+  it('prefers general elections over runoffs', () => {
+    const races = [
+      makeRace({ electionDate: new Date('2026-12-15'), isRunoff: true }),
+      makeRace({ electionDate: new Date('2027-11-02') }),
+    ]
+    const chosen = pickRelevantRace(races)
+    expect(chosen?.isRunoff).toBe(false)
+  })
+
+  it('picks the nearest future general election among many', () => {
+    const races = [
+      makeRace({ electionDate: new Date('2030-11-05') }),
+      makeRace({ electionDate: new Date('2026-11-03') }),
+      makeRace({ electionDate: new Date('2028-11-07') }),
+    ]
+    const chosen = pickRelevantRace(races)
+    expect(chosen?.electionDate.toISOString()).toBe(
+      new Date('2026-11-03').toISOString(),
+    )
+  })
+
+  it('falls back to primary/runoff races when no general election exists', () => {
+    const races = [
+      makeRace({ electionDate: new Date('2027-03-15'), isPrimary: true }),
+      makeRace({ electionDate: new Date('2027-06-15'), isRunoff: true }),
+    ]
+    const chosen = pickRelevantRace(races)
+    expect(chosen).not.toBeNull()
+    // earliest future is the primary
+    expect(chosen?.electionDate.toISOString()).toBe(
+      new Date('2027-03-15').toISOString(),
+    )
+  })
+
+  it('returns the most recent historical race when nothing is in the future', () => {
+    const races = [
+      makeRace({ electionDate: new Date('2020-11-03') }),
+      makeRace({ electionDate: new Date('2024-11-05') }),
+      makeRace({ electionDate: new Date('2022-11-08') }),
+    ]
+    const chosen = pickRelevantRace(races)
+    expect(chosen?.electionDate.toISOString()).toBe(
+      new Date('2024-11-05').toISOString(),
+    )
+  })
+
+  it('historical fallback also prefers general over primary', () => {
+    const races = [
+      makeRace({ electionDate: new Date('2024-03-05'), isPrimary: true }),
+      makeRace({ electionDate: new Date('2022-11-08') }),
+    ]
+    const chosen = pickRelevantRace(races)
+    expect(chosen?.isPrimary).toBe(false)
+    expect(chosen?.electionDate.toISOString()).toBe(
+      new Date('2022-11-08').toISOString(),
+    )
+  })
+
+  it('returns a race with filing data passed through unchanged', () => {
+    const race = makeRace({
+      electionDate: new Date('2027-11-02'),
+      filingRequirements: 'Filing fee is $250.',
+      salary: '$80,000 annual',
+    })
+    const chosen = pickRelevantRace([race])
+    expect(chosen?.filingRequirements).toBe('Filing fee is $250.')
+    expect(chosen?.salary).toBe('$80,000 annual')
+  })
+})

--- a/src/positions/util/pickRelevantRace.util.ts
+++ b/src/positions/util/pickRelevantRace.util.ts
@@ -1,0 +1,51 @@
+import type { Race } from '@prisma/client'
+
+/**
+ * One BallotReady Position can correspond to many Race rows: separate primary
+ * and general election dates, runoffs, and one race per election cycle. The
+ * filing-fee lookup needs a single race to read `filingRequirements` + `salary`
+ * from, so this helper picks the most relevant one in priority order:
+ *
+ *   1. Race whose `electionDate` exactly matches the caller-provided
+ *      `electionDate` (covers the common "I know exactly which race" case).
+ *   2. Within general elections only (skip primaries + runoffs), the nearest
+ *      future race by `electionDate`. Primaries get filtered out because their
+ *      filing fees usually differ from general-election fees, and the general
+ *      is the canonical "this is what running costs" answer.
+ *   3. If no general elections exist, fall back to *any* race (primary/runoff
+ *      included) using the same future-then-past preference.
+ *   4. If no future races, the most recent historical race.
+ *
+ * Returns `null` only when the input list is empty.
+ */
+export type RaceForFilingFee = Pick<
+  Race,
+  'electionDate' | 'isPrimary' | 'isRunoff' | 'filingRequirements' | 'salary'
+>
+
+export const pickRelevantRace = (
+  races: RaceForFilingFee[],
+  electionDate?: string,
+): RaceForFilingFee | null => {
+  if (races.length === 0) return null
+
+  if (electionDate) {
+    const target = new Date(electionDate).getTime()
+    const exact = races.find((r) => r.electionDate.getTime() === target)
+    if (exact) return exact
+  }
+
+  const generalRaces = races.filter((r) => !r.isPrimary && !r.isRunoff)
+  const pool = generalRaces.length > 0 ? generalRaces : races
+  const now = Date.now()
+
+  const future = pool
+    .filter((r) => r.electionDate.getTime() >= now)
+    .sort((a, b) => a.electionDate.getTime() - b.electionDate.getTime())
+  if (future.length > 0) return future[0] ?? null
+
+  const past = [...pool].sort(
+    (a, b) => b.electionDate.getTime() - a.electionDate.getTime(),
+  )
+  return past[0] ?? null
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `includeFilingFee` query flag to `GET /positions/:id` and `GET /positions/by-ballotready-id/:brPositionId`. When enabled, the position response carries a per-race filing fee derived from BallotReady's `filing_requirements` text plus the raw text itself, so a downstream consumer (gp-api → gp-webapp's onboarding outreach-plan step) can replace its current `$400` hardcoded placeholder with a real number.

## Design choices

- **Race join is by `placeId` + `positionNames`, not a foreign key.** Position and Race share no FK in the schema. The de-facto join is `Race.placeId = Position.placeId` AND `Race.positionNames has Position.name`. Spot-checking against real data is worth doing before this hits production — if `positionNames` doesn't always contain the literal `Position.name`, fees will silently come back `null`.
- **One position has many races; we pick the most relevant one.** Priority order: exact `electionDate` match → nearest future general election (primary/runoff filtered out) → nearest future of any kind → most recent historical. Lives in `pickRelevantRace.util.ts` so it's testable in isolation.
- **Multi-value rows nulled out, not first-match.** The data team's SQL picks the first `$X` match; ~8% of rows have separate D/R vs. independent fees, and the first-match heuristic silently lies. This implementation returns the raw text with `extractionSource: 'multi_value'` and a null fee, so the UI can render a "fee varies — see BallotReady" affordance.
- **Raw `filing_requirements` text always passed through.** Even when no fee was extracted (multi-value, no-match, percent-of-salary unresolvable), the raw BR text is returned so the UI can always link to the source.
- **Default response unchanged.** All three new fields are optional and only set when `includeFilingFee=true`. No existing consumers see a shape change.

## Files

- `src/positions/util/filingFee.util.ts` — regex extraction, mirrors the dbt staging query
- `src/positions/util/pickRelevantRace.util.ts` — race-selection tie-breaking
- `src/positions/positions.service.ts` — `lookupFilingFee` private method, `baseSelect` adds `placeId`, filing-fee fields spread into all three response shapes
- `src/positions/positions.schema.ts` — `includeFilingFee` Zod field with the same boolean preprocessor as `includeTurnout`
- `src/positions/positions.controller.ts` — flag plumbed through both endpoints
- `src/positions/positions.types.ts` — three optional fields on `PositionWithOptionalDistrict`

## Test coverage

43 tests across three files:

- `filingFee.util.test.ts` (11) — every extraction bucket (`direct_dollar`, `no_fee`, `pct_of_salary`, `pct_of_salary_unresolvable`, `multi_value`, `no_match`), null/empty inputs, raw-text pass-through.
- `pickRelevantRace.util.test.ts` (11) — exact-date match, general-over-primary/runoff, future-over-past, primary/runoff fallback when no general, historical fallback.
- `positions.service.test.ts` (21, includes 7 new filing-fee scenarios) — flag-off, no-placeId, no-race-match, happy path, electionDate match, multi-value, `pct_of_salary` end-to-end, and the fields landing on the `includeDistrict` and `includeTurnout` response shapes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds optional data fetching/parsing and a new cross-table lookup (`Position` -> `Race`) based on `placeId`/name matching; incorrect or missing joins/regex edge cases could yield null/incorrect fees, though the change is gated behind `includeFilingFee` and defaults remain unchanged.
> 
> **Overview**
> Adds an opt-in `includeFilingFee` query flag to `GET /positions/:id` and `GET /positions/by-ballotready-id/:brPositionId` that, when enabled, enriches the position response with `filingFee`, `filingRequirementsText`, and `filingFeeExtractionSource`.
> 
> Implements a `Race` lookup keyed by `placeId` + `positionNames` and selects the most relevant race (`pickRelevantRace`), then derives the fee from BallotReady free-text requirements (`extractFilingFee`) including handling for *no fee*, *percent of salary*, and *multi-dollar* cases; updates schemas/types and adds focused unit/service tests for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979e7b62fb630cc10025a35578cad27b08800e63. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->