### PR TITLE
chore(positions): add diagnostic logging to filing-fee lookup

### DIFF
--- a/src/positions/positions.service.ts
+++ b/src/positions/positions.service.ts
@@ -275,7 +275,16 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
       filingRequirementsText: null,
       extractionSource: null,
     }
-    if (!position.placeId || !position.name) return empty
+    if (!position.placeId || !position.name) {
+      this.logger.debug({
+        event: 'FilingFeeLookup',
+        outcome: 'skipped',
+        reason: !position.placeId ? 'no_place_id' : 'no_name',
+        positionId: position.id,
+        positionName: position.name,
+      })
+      return empty
+    }
 
     const races = await this.client.race.findMany({
       where: {
@@ -290,11 +299,48 @@ export class PositionsService extends createPrismaBase(MODELS.Position) {
         salary: true,
       },
     })
-    if (races.length === 0) return empty
+
+    if (races.length === 0) {
+      // Diagnose: peek at what positionNames exist for this place so we can
+      // see whether the join is failing because the name string differs from
+      // what's stored on Race rows.
+      const sampleNames = await this.client.race.findMany({
+        where: { placeId: position.placeId },
+        select: { positionNames: true },
+        take: 5,
+      })
+      this.logger.debug({
+        event: 'FilingFeeLookup',
+        outcome: 'no_race_match',
+        positionId: position.id,
+        positionName: position.name,
+        placeId: position.placeId,
+        sampleRacePositionNames: sampleNames.flatMap((r) => r.positionNames),
+      })
+      return empty
+    }
 
     const chosen = pickRelevantRace(races, electionDate)
     if (!chosen) return empty
 
-    return extractFilingFee(chosen.filingRequirements, chosen.salary)
+    const fee = extractFilingFee(chosen.filingRequirements, chosen.salary)
+
+    this.logger.debug({
+      event: 'FilingFeeLookup',
+      outcome: 'matched',
+      positionId: position.id,
+      positionName: position.name,
+      placeId: position.placeId,
+      racesMatched: races.length,
+      chosenElectionDate: chosen.electionDate,
+      chosenIsPrimary: chosen.isPrimary,
+      chosenIsRunoff: chosen.isRunoff,
+      hasFilingRequirements: Boolean(chosen.filingRequirements),
+      hasSalary: Boolean(chosen.salary),
+      filingFee: fee.filingFee,
+      extractionSource: fee.extractionSource,
+    })
+
+    return fee
   }
 }


### PR DESCRIPTION
## Summary

Logging-only follow-up to #165. Surfaces which branch the filing-fee lookup took so we can debug null-fee responses in dev **without DB access**.

This commit was on the original branch but pushed after #165 merged, so it didn't make it in. Cherry-picking now to unblock active filing-fee debugging on dev.

## What it logs

`debug` level (visible in dev, off in prod unless explicitly enabled). Every `lookupFilingFee` call emits one of:

- `outcome: 'skipped'` with `reason: 'no_place_id'` or `'no_name'` — the Position row doesn't have the fields we need to look up a Race.
- `outcome: 'no_race_match'` — `placeId` was set, but no Race row matched `placeId + positionNames`. Also logs `sampleRacePositionNames` (up to 5 races' `position_names` arrays for the same `placeId`) so we can see what names actually exist and decide whether to loosen the join.
- `outcome: 'matched'` — race(s) found. Logs which race we picked, whether it had `filing_requirements` / `salary`, and what `extractFilingFee` returned (so `multi_value` / `no_match` / `pct_of_salary_unresolvable` show up here too).

## Why now

Current state: PR #165 is merged but every filing-fee response in dev comes back `null` — including for positions where we expected real data (e.g. position `c61611f1-7d9d-666f-c759-8fce3c3fc457`, "Denver City Council - At Large"). The API response alone can't distinguish "Position has no `placeId`" from "Race join produced zero rows" — both render as identical-looking nulls. This commit makes the distinction visible in logs.

## Risk / blast radius

- **Behavior:** zero change — only adds `this.logger.debug(...)` calls.
- **Performance:** one additional small query (`SELECT positionNames FROM Race WHERE placeId = ... LIMIT 5`) on the `no_race_match` branch only. Doesn't fire on the success path.
- **Test coverage:** existing 45-test suite passes; no test changes needed since logging output is a side effect.

## Test plan

- [ ] Merge + wait for dev redeploy.
- [ ] Hit `GET /v1/positions/c61611f1-7d9d-666f-c759-8fce3c3fc457?includeDistrict=true&includeTurnout=true&electionDate=2027-04-06&includeFilingFee=true` against `https://election-api-dev.goodparty.org`.
- [ ] Check dev logs for a `FilingFeeLookup` line. The `outcome` field tells us which branch fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is unchanged aside from additional `debug` logs and a small extra query only when no races match, with minimal performance impact.
> 
> **Overview**
> Adds structured `debug`-level diagnostics to `PositionsService.lookupFilingFee` to make null filing-fee responses explainable.
> 
> The lookup now logs when it is **skipped** (missing `placeId`/`name`), when there is **no race match** (including a small sample of `Race.positionNames` for the `placeId`), and when a race is **matched** (including chosen race attributes and the `extractFilingFee` result).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdfd6658b335c3ffa0c5caba011e8259e79b1511. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->