### PR TITLE
[DATA-1922] Drop gp_candidate_id from Candidacy

### DIFF
--- a/prisma/migrations/20260518190000_drop_gp_candidate_id_from_candidacy/migration.sql
+++ b/prisma/migrations/20260518190000_drop_gp_candidate_id_from_candidacy/migration.sql
@@ -1,0 +1,10 @@
+-- Drop gp_candidate_id from Candidacy (DATA-1922 follow-up).
+-- The column was added by 20260518180000_widen_race_candidacy_for_onboarding
+-- but pulled from scope before any consumer started using it. The dbt mart
+-- still resolves gp_candidate_id internally to look up is_incumbent but no
+-- longer writes it to Postgres.
+--
+-- IF EXISTS guards against the case where the prior migration has not yet
+-- been deployed to a given environment (the column never got created).
+
+ALTER TABLE "Candidacy" DROP COLUMN IF EXISTS "gp_candidate_id";

--- a/prisma/schema/candidacy.prisma
+++ b/prisma/schema/candidacy.prisma
@@ -14,11 +14,10 @@ model Candidacy {
   slug         String   @unique // slugify firstName-lastName-normalizedPositionName
 
   // Candidacy
-  firstName     String  @map("first_name")
-  lastName      String  @map("last_name")
-  party         String? // Use index 0 of parties array
-  gpCandidateId String? @map("gp_candidate_id") // Canonical civics candidate ID
-  isIncumbent   Boolean? @map("is_incumbent")
+  firstName   String   @map("first_name")
+  lastName    String   @map("last_name")
+  party       String? // Use index 0 of parties array
+  isIncumbent Boolean? @map("is_incumbent")
 
   // Race for state, and potentially longest geoid Place on Race?
   placeName String? @map("place_name")


### PR DESCRIPTION
## Summary

Follow-up to [#169](https://github.com/thegoodparty/election-api/pull/169). The merged PR added `gp_candidate_id` to `Candidacy`, but the column was pulled from scope before any consumer started using it. This PR drops the column cleanly.

Adding a **new migration** rather than editing `20260518180000_widen_race_candidacy_for_onboarding/migration.sql` in place — Prisma's `_prisma_migrations` table stores per-migration checksums, so editing a merged migration would break drift detection in any environment that has already applied it.

## Changes

1. `prisma/schema/candidacy.prisma` — remove the `gpCandidateId` field.
2. `prisma/migrations/20260518190000_drop_gp_candidate_id_from_candidacy/migration.sql`:
   ```sql
   ALTER TABLE "Candidacy" DROP COLUMN IF EXISTS "gp_candidate_id";
   ```

`IF EXISTS` is defensive — the migration cleanly no-ops in any environment where `20260518180000_*` hasn't been deployed yet (the column would never have been created).

## Why drop it

`gp_candidate_id` was originally on the ticket as a join key from election-api back to the civics mart. The dbt mart ([gp-data-platform#404](https://github.com/thegoodparty/gp-data-platform/pull/404)) still resolves `gp_candidate_id` internally to look up `is_incumbent` from civics, but writing it to Postgres added a column with no current consumer and committed us to a contract before we had a use case.

`is_incumbent` (also added by #169) stays — that one has a consumer (the onboarding LLM campaign planner).

## Migration safety

- Backward-compatible: the column is nullable and has no FK references.
- No app code references `gpCandidateId` (column was never wired into any service / schema allowlist beyond what Prisma auto-generates).
- `IF EXISTS` covers the "not-yet-applied" case.

## Test plan

- [ ] CI passes (`npm ci` regenerates the Prisma client; `npx tsc --noEmit` confirms no type breakage)
- [ ] Migration applies cleanly against staging Postgres (drops the column if present, no-ops otherwise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)