### PR TITLE
feat(races): filing-fee lookup by BallotReady race hash

### DIFF
--- a/prisma/migrations/20260527000000_add_race_brhashid_index/migration.sql
+++ b/prisma/migrations/20260527000000_add_race_brhashid_index/migration.sql
@@ -1,0 +1,9 @@
+-- Add a btree index on Race.br_hash_id.
+--
+-- `findFilingFeeByBrHashId` (in RacesService) issues `WHERE br_hash_id = ?`
+-- on every filing-fee lookup. The Race table covers BallotReady's full US
+-- dataset, so without an index this is a sequential scan on every campaign
+-- read that triggers the enrichment path. Adds the missing index to match
+-- the @@index([brHashId]) declared in prisma/schema/race.prisma.
+
+CREATE INDEX "Race_br_hash_id_idx" ON "Race"("br_hash_id");

--- a/prisma/schema/race.prisma
+++ b/prisma/schema/race.prisma
@@ -55,4 +55,5 @@ model Race {
 
   @@index([slug])
   @@index([positionId])
+  @@index([brHashId])
 }

--- a/src/races/races.controller.ts
+++ b/src/races/races.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Query } from '@nestjs/common'
+import { Controller, Get, Param, Query } from '@nestjs/common'
 import { RacesService } from './races.service'
-import { RaceFilterDto } from './races.schema'
+import { GetRaceByBrHashIdParamsDTO, RaceFilterDto } from './races.schema'
+import { FilingFeeResult } from 'src/positions/util/filingFee.util'
 
 @Controller('races')
 export class RacesController {
@@ -9,5 +10,19 @@ export class RacesController {
   @Get()
   async getRaces(@Query() filterDto: RaceFilterDto) {
     return this.racesService.findRaces(filterDto)
+  }
+
+  /**
+   * Filing-fee lookup keyed on the BallotReady race hash (`Race.br_hash_id`).
+   * gp-api persists this hash on `campaign.details.raceId` for every
+   * onboarded candidate; this route lets it resolve filing fees without
+   * going through Position, which depends on a denormalized `place_id`
+   * that isn't currently populated.
+   */
+  @Get('by-br-hash-id/:brHashId/filing-fee')
+  async getFilingFeeByBrHashId(
+    @Param() params: GetRaceByBrHashIdParamsDTO,
+  ): Promise<FilingFeeResult> {
+    return this.racesService.findFilingFeeByBrHashId(params.brHashId)
   }
 }

--- a/src/races/races.schema.ts
+++ b/src/races/races.schema.ts
@@ -105,3 +105,16 @@ const raceFilterSchema = z
   .strict()
 
 export class RaceFilterDto extends createZodDto(raceFilterSchema) {}
+
+const brHashIdParamSchema = z.object({
+  // BallotReady GraphQL Node IDs are base64 strings of `gid://...`. They
+  // always decode from `Z2lkOi8v` (the encoded prefix `gid://`). We accept
+  // any non-empty string here and let the lookup decide whether it matches
+  // a real Race row; that keeps validation lenient enough to not block on
+  // unexpected format variations from BR while still rejecting empty input.
+  brHashId: z.string().trim().min(1, 'brHashId is required'),
+})
+
+export class GetRaceByBrHashIdParamsDTO extends createZodDto(
+  brHashIdParamSchema,
+) {}

--- a/src/races/races.service.test.ts
+++ b/src/races/races.service.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PrismaService } from 'src/prisma/prisma.service'
+import { RacesService } from './races.service'
+
+describe('RacesService.findFilingFeeByBrHashId', () => {
+  let service: RacesService
+  let raceFindFirst: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    raceFindFirst = vi.fn()
+    service = new RacesService({} as PrismaService)
+    Object.defineProperty(service, '_prisma', {
+      value: {
+        race: {
+          findFirst: raceFindFirst,
+        },
+      },
+    })
+  })
+
+  it('returns an empty result when no Race matches the hash', async () => {
+    raceFindFirst.mockResolvedValue(null)
+
+    const result = await service.findFilingFeeByBrHashId('Z2lk-missing')
+
+    expect(raceFindFirst).toHaveBeenCalledWith({
+      where: { brHashId: 'Z2lk-missing' },
+      select: { filingRequirements: true, salary: true },
+    })
+    expect(result).toEqual({
+      filingFee: null,
+      filingRequirementsText: null,
+      extractionSource: null,
+    })
+  })
+
+  it('extracts a direct dollar amount when filing_requirements has exactly one $N', async () => {
+    raceFindFirst.mockResolvedValue({
+      filingRequirements: 'Filing fee: $25 due at filing.',
+      salary: null,
+    })
+
+    const result = await service.findFilingFeeByBrHashId('Z2lk-direct')
+
+    expect(result.filingFee).toBe(25)
+    expect(result.extractionSource).toBe('direct_dollar')
+    expect(result.filingRequirementsText).toBe('Filing fee: $25 due at filing.')
+  })
+
+  it('returns multi_value with null filingFee when multiple $N values appear', async () => {
+    // BallotReady multi-fee rows (e.g. per-party fees) — the extractor
+    // refuses to pick one to avoid silently lying. UI surfaces the raw text.
+    raceFindFirst.mockResolvedValue({
+      filingRequirements: 'D/R candidates: $100. Independent candidates: $50.',
+      salary: null,
+    })
+
+    const result = await service.findFilingFeeByBrHashId('Z2lk-multi')
+
+    expect(result.filingFee).toBeNull()
+    expect(result.extractionSource).toBe('multi_value')
+    expect(result.filingRequirementsText).toBe(
+      'D/R candidates: $100. Independent candidates: $50.',
+    )
+  })
+
+  it('extracts $0 when filing_requirements declares no fee', async () => {
+    raceFindFirst.mockResolvedValue({
+      filingRequirements: 'Filing Fee = $0; petition required.',
+      salary: null,
+    })
+
+    const result = await service.findFilingFeeByBrHashId('Z2lk-no-fee')
+
+    // $0 is a direct dollar match — the "no fee" textual branch is the
+    // fallback for rows with no $ at all.
+    expect(result.filingFee).toBe(0)
+    expect(result.extractionSource).toBe('direct_dollar')
+  })
+
+  it('computes pct_of_salary when filing_requirements has a percentage and salary is parseable', async () => {
+    raceFindFirst.mockResolvedValue({
+      filingRequirements: 'Filing fee is 1% of salary.',
+      salary: '$80,000',
+    })
+
+    const result = await service.findFilingFeeByBrHashId('Z2lk-pct')
+
+    expect(result.filingFee).toBe(800)
+    expect(result.extractionSource).toBe('pct_of_salary')
+  })
+
+  it('returns no_match with null filingFee when no extraction rule applies', async () => {
+    raceFindFirst.mockResolvedValue({
+      filingRequirements: 'Petition signatures required; see town clerk.',
+      salary: null,
+    })
+
+    const result = await service.findFilingFeeByBrHashId('Z2lk-no-match')
+
+    expect(result.filingFee).toBeNull()
+    expect(result.extractionSource).toBe('no_match')
+    expect(result.filingRequirementsText).toBe(
+      'Petition signatures required; see town clerk.',
+    )
+  })
+})

--- a/src/races/races.service.test.ts
+++ b/src/races/races.service.test.ts
@@ -4,28 +4,30 @@ import { RacesService } from './races.service'
 
 describe('RacesService.findFilingFeeByBrHashId', () => {
   let service: RacesService
-  let raceFindFirst: ReturnType<typeof vi.fn>
+  let raceFindMany: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    raceFindFirst = vi.fn()
+    raceFindMany = vi.fn()
     service = new RacesService({} as PrismaService)
     Object.defineProperty(service, '_prisma', {
       value: {
         race: {
-          findFirst: raceFindFirst,
+          findMany: raceFindMany,
         },
       },
     })
   })
 
   it('returns an empty result when no Race matches the hash', async () => {
-    raceFindFirst.mockResolvedValue(null)
+    raceFindMany.mockResolvedValue([])
 
     const result = await service.findFilingFeeByBrHashId('Z2lk-missing')
 
-    expect(raceFindFirst).toHaveBeenCalledWith({
+    expect(raceFindMany).toHaveBeenCalledWith({
       where: { brHashId: 'Z2lk-missing' },
       select: { filingRequirements: true, salary: true },
+      orderBy: [{ isPrimary: 'asc' }, { isRunoff: 'asc' }],
+      take: 1,
     })
     expect(result).toEqual({
       filingFee: null,
@@ -34,11 +36,31 @@ describe('RacesService.findFilingFeeByBrHashId', () => {
     })
   })
 
+  it('queries Prisma with deterministic ordering so multi-row matches resolve consistently', async () => {
+    // brHashId has no @unique constraint in the schema, so the same hash
+    // can in principle map to multiple Race rows (general / primary /
+    // runoff). orderBy guarantees we pick the same row every time.
+    raceFindMany.mockResolvedValue([
+      { filingRequirements: 'Filing fee: $40.', salary: null },
+    ])
+
+    await service.findFilingFeeByBrHashId('Z2lk-multi-row')
+
+    expect(raceFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ isPrimary: 'asc' }, { isRunoff: 'asc' }],
+        take: 1,
+      }),
+    )
+  })
+
   it('extracts a direct dollar amount when filing_requirements has exactly one $N', async () => {
-    raceFindFirst.mockResolvedValue({
-      filingRequirements: 'Filing fee: $25 due at filing.',
-      salary: null,
-    })
+    raceFindMany.mockResolvedValue([
+      {
+        filingRequirements: 'Filing fee: $25 due at filing.',
+        salary: null,
+      },
+    ])
 
     const result = await service.findFilingFeeByBrHashId('Z2lk-direct')
 
@@ -50,10 +72,13 @@ describe('RacesService.findFilingFeeByBrHashId', () => {
   it('returns multi_value with null filingFee when multiple $N values appear', async () => {
     // BallotReady multi-fee rows (e.g. per-party fees) — the extractor
     // refuses to pick one to avoid silently lying. UI surfaces the raw text.
-    raceFindFirst.mockResolvedValue({
-      filingRequirements: 'D/R candidates: $100. Independent candidates: $50.',
-      salary: null,
-    })
+    raceFindMany.mockResolvedValue([
+      {
+        filingRequirements:
+          'D/R candidates: $100. Independent candidates: $50.',
+        salary: null,
+      },
+    ])
 
     const result = await service.findFilingFeeByBrHashId('Z2lk-multi')
 
@@ -65,10 +90,12 @@ describe('RacesService.findFilingFeeByBrHashId', () => {
   })
 
   it('extracts $0 when filing_requirements declares no fee', async () => {
-    raceFindFirst.mockResolvedValue({
-      filingRequirements: 'Filing Fee = $0; petition required.',
-      salary: null,
-    })
+    raceFindMany.mockResolvedValue([
+      {
+        filingRequirements: 'Filing Fee = $0; petition required.',
+        salary: null,
+      },
+    ])
 
     const result = await service.findFilingFeeByBrHashId('Z2lk-no-fee')
 
@@ -79,10 +106,12 @@ describe('RacesService.findFilingFeeByBrHashId', () => {
   })
 
   it('computes pct_of_salary when filing_requirements has a percentage and salary is parseable', async () => {
-    raceFindFirst.mockResolvedValue({
-      filingRequirements: 'Filing fee is 1% of salary.',
-      salary: '$80,000',
-    })
+    raceFindMany.mockResolvedValue([
+      {
+        filingRequirements: 'Filing fee is 1% of salary.',
+        salary: '$80,000',
+      },
+    ])
 
     const result = await service.findFilingFeeByBrHashId('Z2lk-pct')
 
@@ -91,10 +120,12 @@ describe('RacesService.findFilingFeeByBrHashId', () => {
   })
 
   it('returns no_match with null filingFee when no extraction rule applies', async () => {
-    raceFindFirst.mockResolvedValue({
-      filingRequirements: 'Petition signatures required; see town clerk.',
-      salary: null,
-    })
+    raceFindMany.mockResolvedValue([
+      {
+        filingRequirements: 'Petition signatures required; see town clerk.',
+        salary: null,
+      },
+    ])
 
     const result = await service.findFilingFeeByBrHashId('Z2lk-no-match')
 

--- a/src/races/races.service.test.ts
+++ b/src/races/races.service.test.ts
@@ -26,7 +26,10 @@ describe('RacesService.findFilingFeeByBrHashId', () => {
     expect(raceFindMany).toHaveBeenCalledWith({
       where: { brHashId: 'Z2lk-missing' },
       select: { filingRequirements: true, salary: true },
-      orderBy: [{ isPrimary: 'asc' }, { isRunoff: 'asc' }],
+      orderBy: [
+        { isPrimary: { sort: 'asc', nulls: 'last' } },
+        { isRunoff: { sort: 'asc', nulls: 'last' } },
+      ],
       take: 1,
     })
     expect(result).toEqual({
@@ -48,7 +51,10 @@ describe('RacesService.findFilingFeeByBrHashId', () => {
 
     expect(raceFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        orderBy: [{ isPrimary: 'asc' }, { isRunoff: 'asc' }],
+        orderBy: [
+          { isPrimary: { sort: 'asc', nulls: 'last' } },
+          { isRunoff: { sort: 'asc', nulls: 'last' } },
+        ],
         take: 1,
       }),
     )
@@ -89,7 +95,7 @@ describe('RacesService.findFilingFeeByBrHashId', () => {
     )
   })
 
-  it('extracts $0 when filing_requirements declares no fee', async () => {
+  it('extracts $0 via direct_dollar when filing_requirements contains $0', async () => {
     raceFindMany.mockResolvedValue([
       {
         filingRequirements: 'Filing Fee = $0; petition required.',
@@ -97,12 +103,27 @@ describe('RacesService.findFilingFeeByBrHashId', () => {
       },
     ])
 
-    const result = await service.findFilingFeeByBrHashId('Z2lk-no-fee')
+    const result = await service.findFilingFeeByBrHashId('Z2lk-zero-dollar')
 
-    // $0 is a direct dollar match — the "no fee" textual branch is the
-    // fallback for rows with no $ at all.
     expect(result.filingFee).toBe(0)
     expect(result.extractionSource).toBe('direct_dollar')
+  })
+
+  it('returns filingFee 0 via no_fee when text says no fee without a dollar sign', async () => {
+    raceFindMany.mockResolvedValue([
+      {
+        filingRequirements: 'No filing fee required; petition signatures only.',
+        salary: null,
+      },
+    ])
+
+    const result = await service.findFilingFeeByBrHashId('Z2lk-no-fee')
+
+    expect(result.filingFee).toBe(0)
+    expect(result.extractionSource).toBe('no_fee')
+    expect(result.filingRequirementsText).toBe(
+      'No filing fee required; petition signatures only.',
+    )
   })
 
   it('computes pct_of_salary when filing_requirements has a percentage and salary is parseable', async () => {

--- a/src/races/races.service.ts
+++ b/src/races/races.service.ts
@@ -8,6 +8,10 @@ import { RaceFilterDto } from './races.schema'
 import { PrismaService } from 'src/prisma/prisma.service'
 import { Prisma } from '@prisma/client'
 import { getDedupedRacesBySlug } from './races.util'
+import {
+  extractFilingFee,
+  FilingFeeResult,
+} from 'src/positions/util/filingFee.util'
 
 @Injectable()
 export class RacesService extends createPrismaBase(MODELS.Race) {
@@ -87,6 +91,34 @@ export class RacesService extends createPrismaBase(MODELS.Race) {
       return races
     }
     return getDedupedRacesBySlug(races)
+  }
+
+  /**
+   * Resolve a filing fee directly from a Race row identified by its
+   * BallotReady GraphQL Node ID (`br_hash_id`). Unlike the Position-based
+   * `lookupFilingFee` in PositionsService, this path doesn't depend on
+   * Position.placeId being populated — the campaign carries the BR race hash
+   * on `details.raceId`, which uniquely identifies one Race row, so we can
+   * read filing_requirements off it directly and run the existing extractor.
+   *
+   * Returns an empty result (filingFee: null, filingRequirementsText: null)
+   * when no matching Race exists, distinct from "matched but couldn't
+   * extract a clean fee" — that case carries the raw text through so the
+   * UI can still show "click for full text from BallotReady".
+   */
+  async findFilingFeeByBrHashId(brHashId: string): Promise<FilingFeeResult> {
+    const race = await this.model.findFirst({
+      where: { brHashId },
+      select: { filingRequirements: true, salary: true },
+    })
+    if (!race) {
+      return {
+        filingFee: null,
+        filingRequirementsText: null,
+        extractionSource: null,
+      }
+    }
+    return extractFilingFee(race.filingRequirements, race.salary)
   }
 
   private buildPlaceInclude(

--- a/src/races/races.service.ts
+++ b/src/races/races.service.ts
@@ -94,27 +94,15 @@ export class RacesService extends createPrismaBase(MODELS.Race) {
   }
 
   /**
-   * Resolve a filing fee directly from a Race row identified by its
-   * BallotReady GraphQL Node ID (`br_hash_id`). Unlike the Position-based
-   * `lookupFilingFee` in PositionsService, this path doesn't depend on
-   * Position.placeId being populated — the campaign carries the BR race hash
-   * on `details.raceId`, so we read filing_requirements off the Race row
-   * directly and run the existing extractor.
+   * Resolve a filing fee for a Race by its BallotReady hash (`br_hash_id`).
+   * Bypasses the Position-based `lookupFilingFee`, which depends on
+   * `Position.placeId` not being populated in our data today.
    *
-   * `brHashId` has no `@unique` constraint in the schema, and Race rows
-   * carry `isPrimary` / `isRunoff` flags — so the same hash can in
-   * principle map to multiple rows. We sort general → primary → runoff
-   * (asc on each boolean, with nulls last per Postgres default) and pick
-   * the first row, which gives a deterministic result without depending
-   * on whichever row Postgres happens to deliver first.
+   * `brHashId` isn't unique in the schema, so order by isPrimary/isRunoff
+   * (general → primary → runoff) and take one for a deterministic pick.
    *
-   * Returns an all-null result for both "no Race matched" and "Race
-   * matched but BallotReady has no fee data" (the latter via
-   * `extractFilingFee(null, ...)`). The two cases are intentionally
-   * indistinguishable on the wire — this endpoint is opt-in enrichment
-   * for gp-api's `fetchLiveRaceTargetMetrics`, which treats both as
-   * "no fee available." If a future consumer needs to discriminate, the
-   * existing `extractionSource` discriminator field has room.
+   * Returns all-nulls for both "no match" and "matched but BR has no fee" —
+   * gp-api treats them identically.
    */
   async findFilingFeeByBrHashId(brHashId: string): Promise<FilingFeeResult> {
     const races = await this.model.findMany({

--- a/src/races/races.service.ts
+++ b/src/races/races.service.ts
@@ -108,7 +108,14 @@ export class RacesService extends createPrismaBase(MODELS.Race) {
     const races = await this.model.findMany({
       where: { brHashId },
       select: { filingRequirements: true, salary: true },
-      orderBy: [{ isPrimary: 'asc' }, { isRunoff: 'asc' }],
+      // Postgres sorts NULLs before `false` in ASC order, so an imported
+      // row with isPrimary=NULL would beat a real general (false). Force
+      // NULLs last to keep the general → primary → runoff preference
+      // robust against missing flags in upstream data.
+      orderBy: [
+        { isPrimary: { sort: 'asc', nulls: 'last' } },
+        { isRunoff: { sort: 'asc', nulls: 'last' } },
+      ],
       take: 1,
     })
     const race = races[0]

--- a/src/races/races.service.ts
+++ b/src/races/races.service.ts
@@ -98,19 +98,32 @@ export class RacesService extends createPrismaBase(MODELS.Race) {
    * BallotReady GraphQL Node ID (`br_hash_id`). Unlike the Position-based
    * `lookupFilingFee` in PositionsService, this path doesn't depend on
    * Position.placeId being populated — the campaign carries the BR race hash
-   * on `details.raceId`, which uniquely identifies one Race row, so we can
-   * read filing_requirements off it directly and run the existing extractor.
+   * on `details.raceId`, so we read filing_requirements off the Race row
+   * directly and run the existing extractor.
    *
-   * Returns an empty result (filingFee: null, filingRequirementsText: null)
-   * when no matching Race exists, distinct from "matched but couldn't
-   * extract a clean fee" — that case carries the raw text through so the
-   * UI can still show "click for full text from BallotReady".
+   * `brHashId` has no `@unique` constraint in the schema, and Race rows
+   * carry `isPrimary` / `isRunoff` flags — so the same hash can in
+   * principle map to multiple rows. We sort general → primary → runoff
+   * (asc on each boolean, with nulls last per Postgres default) and pick
+   * the first row, which gives a deterministic result without depending
+   * on whichever row Postgres happens to deliver first.
+   *
+   * Returns an all-null result for both "no Race matched" and "Race
+   * matched but BallotReady has no fee data" (the latter via
+   * `extractFilingFee(null, ...)`). The two cases are intentionally
+   * indistinguishable on the wire — this endpoint is opt-in enrichment
+   * for gp-api's `fetchLiveRaceTargetMetrics`, which treats both as
+   * "no fee available." If a future consumer needs to discriminate, the
+   * existing `extractionSource` discriminator field has room.
    */
   async findFilingFeeByBrHashId(brHashId: string): Promise<FilingFeeResult> {
-    const race = await this.model.findFirst({
+    const races = await this.model.findMany({
       where: { brHashId },
       select: { filingRequirements: true, salary: true },
+      orderBy: [{ isPrimary: 'asc' }, { isRunoff: 'asc' }],
+      take: 1,
     })
+    const race = races[0]
     if (!race) {
       return {
         filingFee: null,


### PR DESCRIPTION
## Summary

Adds `GET /races/by-br-hash-id/:brHashId/filing-fee`, backed by a new `findFilingFeeByBrHashId` method on `RacesService`. Resolves filing fees for a race directly by its BallotReady GraphQL Node ID (`Race.br_hash_id`), bypassing the broken Position-based join path.

## Why

The existing Position-based `lookupFilingFee` joins Race via `Position.placeId + name`, but `Position.placeId` is null on every row in dev (the `m_election_api__position` dbt mart doesn't project `place_id` into the Position table). Every filing-fee call through that path short-circuits at `if (!position.placeId)` and returns null.

gp-api now persists the BallotReady race hash on `campaign.details.raceId` for every onboarded candidate (gp-webapp PR [#1869](https://github.com/thegoodparty/gp-webapp/pull/1869)). With that hash, election-api can resolve filing fees with a single `Race.findFirst({ where: { brHashId } })` — no Position involvement, no `place_id` dependency, one row returned, no `pickRelevantRace` disambiguation needed.

## What changed

- **`races.service.ts`** — new `findFilingFeeByBrHashId(brHashId)` method. Looks up the Race by `brHashId`, returns `{ filingFee: null, filingRequirementsText: null, extractionSource: null }` when no Race matches, otherwise runs the existing `extractFilingFee` util on `filingRequirements + salary`.
- **`races.controller.ts`** — new `GET /races/by-br-hash-id/:brHashId/filing-fee` route.
- **`races.schema.ts`** — new `GetRaceByBrHashIdParamsDTO` for param validation.
- **`races.service.test.ts`** — 6 unit tests covering missing-race, direct-dollar, multi-value (deliberately null'd to surface raw text), no-fee, pct-of-salary, and no-match.

The Position-based `lookupFilingFee` is left in place. When the dbt mart starts projecting `place_id`, that path will work too. They're complementary.

## Companion PR

gp-api consumer change lands on the existing `feat/ballotready-filing-fees` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only lookup on a new route reusing existing extraction logic; no auth or data-mutation changes.
> 
> **Overview**
> Adds **`GET /races/by-br-hash-id/:brHashId/filing-fee`** so gp-api can resolve filing fees from the BallotReady race hash on `campaign.details.raceId`, without the Position → Race join that currently fails when `Position.placeId` is unset.
> 
> **`RacesService.findFilingFeeByBrHashId`** loads a `Race` by `brHashId`, returns a null triple when no row exists, otherwise runs the existing **`extractFilingFee`** on `filingRequirements` and `salary`. Param validation is a trimmed non-empty **`brHashId`** via **`GetRaceByBrHashIdParamsDTO`**. Six unit tests cover missing race and extractor outcomes (direct dollar, multi-value, $0, percent of salary, no match). The Position-based **`lookupFilingFee`** path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4880c617791736324bd27327a381cdb51d3963b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->