### PR TITLE
[DATA-1922] Use simple-majority (50% + 1) win-number estimate

### DIFF
--- a/src/campaignStrategyContext/campaign-strategy-context.service.test.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.service.test.ts
@@ -270,36 +270,43 @@ describe('CampaignStrategyContextService', () => {
     expect(result.win_number_estimate).toBe(1137)
   })
 
-  it('returns null win_number_estimate when projected_turnout is 0', async () => {
-    // Postgres ProjectedTurnout.projectedTurnout is unconstrained Int;
-    // a stored 0 would otherwise produce win_number_estimate = 1
-    // ("1 vote needed to win a race with 0 projected voters"), which
-    // is misleading signal for the LLM.
-    raceFindFirst.mockResolvedValue(
-      baseRace({
-        Position: {
-          id: 'pos-uuid-1',
-          district: {
-            id: 'dist-uuid-1',
-            ProjectedTurnouts: [
-              {
-                electionYear: 2026,
-                electionCode: ElectionCode.LocalOrMunicipal,
-                projectedTurnout: 0,
-              },
-            ],
+  it.each([
+    { label: 'zero', projectedTurnout: 0 },
+    { label: 'negative', projectedTurnout: -1 },
+  ])(
+    'returns null win_number_estimate when projected_turnout is $label',
+    async ({ projectedTurnout }) => {
+      // Postgres ProjectedTurnout.projectedTurnout is an unconstrained
+      // Int with no upstream sign validation. A stored 0 would otherwise
+      // produce win_number_estimate = 1 ("1 vote needed to win 0
+      // voters"); negatives produce 0 or negative estimates. All are
+      // misleading signal vs. null.
+      raceFindFirst.mockResolvedValue(
+        baseRace({
+          Position: {
+            id: 'pos-uuid-1',
+            district: {
+              id: 'dist-uuid-1',
+              ProjectedTurnouts: [
+                {
+                  electionYear: 2026,
+                  electionCode: ElectionCode.LocalOrMunicipal,
+                  projectedTurnout,
+                },
+              ],
+            },
           },
-        },
-      }),
-    )
+        }),
+      )
 
-    const result = await service.getCampaignStrategyContext(baseRequest())
+      const result = await service.getCampaignStrategyContext(baseRequest())
 
-    expect(result.projected_turnout).toBe(0)
-    expect(result.win_number_estimate).toBeNull()
-    expect(result.win_number_effective).toBeNull()
-    expect(result.contacts_needed_estimate).toBeNull()
-  })
+      expect(result.projected_turnout).toBe(projectedTurnout)
+      expect(result.win_number_estimate).toBeNull()
+      expect(result.win_number_effective).toBeNull()
+      expect(result.contacts_needed_estimate).toBeNull()
+    },
+  )
 
   it('falls back to LocalOrMunicipal when no ProjectedTurnout row matches the election year/code', async () => {
     raceFindFirst.mockResolvedValue(

--- a/src/campaignStrategyContext/campaign-strategy-context.service.test.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.service.test.ts
@@ -154,7 +154,7 @@ describe('CampaignStrategyContextService', () => {
         },
       ],
       civics_win_number: null,
-      contacts_needed_estimate: 5795,
+      contacts_needed_estimate: 5685,
       general_election_date: '2026-08-25',
       number_of_seats: 1,
       office_level: null,
@@ -164,8 +164,8 @@ describe('CampaignStrategyContextService', () => {
       projected_turnout: 2272,
       relevant_election_date: '2026-08-25',
       state: 'AL',
-      win_number_effective: 1159,
-      win_number_estimate: 1159,
+      win_number_effective: 1137,
+      win_number_estimate: 1137,
     })
   })
 
@@ -216,7 +216,7 @@ describe('CampaignStrategyContextService', () => {
     const result = await service.getCampaignStrategyContext(baseRequest())
 
     expect(result.civics_win_number).toBe(800)
-    expect(result.win_number_estimate).toBe(1159) // ceil(2272 * 0.51 / 1)
+    expect(result.win_number_estimate).toBe(1137) // floor(2272 / 2) + 1
     expect(result.win_number_effective).toBe(800)
     expect(result.contacts_needed_estimate).toBe(4000) // 5 * 800
   })
@@ -250,21 +250,24 @@ describe('CampaignStrategyContextService', () => {
     expect(result.contacts_needed_estimate).toBe(2500)
   })
 
-  it('divides by number_of_seats when computing win_number_estimate', async () => {
+  it('ignores number_of_seats when computing win_number_estimate', async () => {
+    // Multi-seat at-large races use the same simple-majority threshold
+    // as single-seat; consumers that need a per-seat or Droop-quota
+    // multi-seat estimate compute their own. floor(2272 / 2) + 1 = 1137
+    // regardless of seats.
     raceFindFirst.mockResolvedValue(baseRace({ numberOfSeats: 3 }))
 
     const result = await service.getCampaignStrategyContext(baseRequest())
 
-    // ceil(2272 * 0.51 / 3) = ceil(386.24) = 387
-    expect(result.win_number_estimate).toBe(387)
+    expect(result.win_number_estimate).toBe(1137)
   })
 
-  it('treats null number_of_seats as 1 when computing win_number_estimate', async () => {
+  it('does not depend on number_of_seats being non-null', async () => {
     raceFindFirst.mockResolvedValue(baseRace({ numberOfSeats: null }))
 
     const result = await service.getCampaignStrategyContext(baseRequest())
 
-    expect(result.win_number_estimate).toBe(1159)
+    expect(result.win_number_estimate).toBe(1137)
   })
 
   it('falls back to LocalOrMunicipal when no ProjectedTurnout row matches the election year/code', async () => {

--- a/src/campaignStrategyContext/campaign-strategy-context.service.test.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.service.test.ts
@@ -270,6 +270,37 @@ describe('CampaignStrategyContextService', () => {
     expect(result.win_number_estimate).toBe(1137)
   })
 
+  it('returns null win_number_estimate when projected_turnout is 0', async () => {
+    // Postgres ProjectedTurnout.projectedTurnout is unconstrained Int;
+    // a stored 0 would otherwise produce win_number_estimate = 1
+    // ("1 vote needed to win a race with 0 projected voters"), which
+    // is misleading signal for the LLM.
+    raceFindFirst.mockResolvedValue(
+      baseRace({
+        Position: {
+          id: 'pos-uuid-1',
+          district: {
+            id: 'dist-uuid-1',
+            ProjectedTurnouts: [
+              {
+                electionYear: 2026,
+                electionCode: ElectionCode.LocalOrMunicipal,
+                projectedTurnout: 0,
+              },
+            ],
+          },
+        },
+      }),
+    )
+
+    const result = await service.getCampaignStrategyContext(baseRequest())
+
+    expect(result.projected_turnout).toBe(0)
+    expect(result.win_number_estimate).toBeNull()
+    expect(result.win_number_effective).toBeNull()
+    expect(result.contacts_needed_estimate).toBeNull()
+  })
+
   it('falls back to LocalOrMunicipal when no ProjectedTurnout row matches the election year/code', async () => {
     raceFindFirst.mockResolvedValue(
       baseRace({

--- a/src/campaignStrategyContext/campaign-strategy-context.service.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.service.ts
@@ -232,11 +232,13 @@ export class CampaignStrategyContextService extends createPrismaBase(MODELS.Race
   private computeWinNumberEstimate(
     projectedTurnout: number | null,
   ): number | null {
-    // Treat a stored 0 turnout as "unknown": the majority of 0 voters
-    // is 0, not 1, and "you need 1 vote to win" is misleading signal
-    // for the LLM. The Postgres column is an unconstrained Int so a
-    // 0 can flow through from the projection model.
-    if (projectedTurnout === null || projectedTurnout === 0) return null
+    // Treat any non-positive turnout as "unknown". The Postgres column
+    // is an unconstrained Int with no upstream sign validation, so
+    // values <= 0 can flow through from a bad projection run. The
+    // majority of 0 voters is 0, not 1; negative inputs produce 0 or
+    // negative win-number estimates — all are misleading signal for
+    // the LLM compared to null.
+    if (projectedTurnout === null || projectedTurnout <= 0) return null
     // Simple majority threshold: floor(turnout / 2) + 1 is the minimum
     // vote count that guarantees winning a head-to-head majority. Do
     // not divide by numberOfSeats; consumers that need a per-seat or

--- a/src/campaignStrategyContext/campaign-strategy-context.service.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.service.ts
@@ -232,7 +232,11 @@ export class CampaignStrategyContextService extends createPrismaBase(MODELS.Race
   private computeWinNumberEstimate(
     projectedTurnout: number | null,
   ): number | null {
-    if (projectedTurnout === null) return null
+    // Treat a stored 0 turnout as "unknown": the majority of 0 voters
+    // is 0, not 1, and "you need 1 vote to win" is misleading signal
+    // for the LLM. The Postgres column is an unconstrained Int so a
+    // 0 can flow through from the projection model.
+    if (projectedTurnout === null || projectedTurnout === 0) return null
     // Simple majority threshold: floor(turnout / 2) + 1 is the minimum
     // vote count that guarantees winning a head-to-head majority. Do
     // not divide by numberOfSeats; consumers that need a per-seat or

--- a/src/campaignStrategyContext/campaign-strategy-context.service.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.service.ts
@@ -7,11 +7,6 @@ import {
   CampaignStrategyContextResponse,
 } from './campaign-strategy-context.schema'
 
-// Plurality win threshold. A candidate needs > 50% of votes to win; we
-// estimate the bar at 51% to give the consumer a small buffer over the
-// raw majority.
-const WIN_THRESHOLD = 0.51
-
 // Voter contact targets are typically sized at ~5x the win number to
 // account for response rate and persuasion attrition.
 const CONTACTS_NEEDED_MULTIPLIER = 5
@@ -91,10 +86,7 @@ export class CampaignStrategyContextService extends createPrismaBase(MODELS.Race
       race.state,
     )
 
-    const winNumberEstimate = this.computeWinNumberEstimate(
-      projectedTurnout,
-      race.numberOfSeats,
-    )
+    const winNumberEstimate = this.computeWinNumberEstimate(projectedTurnout)
     const winNumberEffective = race.winNumber ?? winNumberEstimate
     const contactsNeededEstimate =
       winNumberEffective !== null
@@ -239,12 +231,13 @@ export class CampaignStrategyContextService extends createPrismaBase(MODELS.Race
 
   private computeWinNumberEstimate(
     projectedTurnout: number | null,
-    numberOfSeats: number | null,
   ): number | null {
     if (projectedTurnout === null) return null
-    const seats =
-      numberOfSeats !== null && numberOfSeats > 0 ? numberOfSeats : 1
-    return Math.ceil((projectedTurnout * WIN_THRESHOLD) / seats)
+    // Simple majority threshold: floor(turnout / 2) + 1 is the minimum
+    // vote count that guarantees winning a head-to-head majority. Do
+    // not divide by numberOfSeats; consumers that need a per-seat or
+    // Droop-quota multi-seat estimate compute their own.
+    return Math.floor(projectedTurnout / 2) + 1
   }
 
   private composeCandidateOffice(


### PR DESCRIPTION
## Summary

Switch the campaign-strategy-context endpoint's `win_number_estimate` formula from `ceil(projected_turnout * 0.51 / number_of_seats)` to `floor(projected_turnout / 2) + 1`, and drop the per-seat division.

## Why

The Campaign Plan template defines "Projected Votes Needed to Win" as a simple majority (50% + 1) of projected voter turnout — not a conservative 51% buffer. Aligning the endpoint's estimate with the template's documented definition keeps the LLM prompt's `{{win_number_estimate}}` consistent with what the rest of the plan document calls out as the win threshold.

The per-seat division is also dropped. The win threshold the LLM consumes is race-level, not per-seat; consumers that need a per-seat or Droop-quota multi-seat estimate compute their own. Confirmed with Nigel in [Slack](https://goodpartyorg.slack.com/archives/...).

## Diff

- `computeWinNumberEstimate(projectedTurnout, numberOfSeats)` → `computeWinNumberEstimate(projectedTurnout)`
- `WIN_THRESHOLD = 0.51` constant removed
- Formula: `Math.floor(projectedTurnout / 2) + 1`
- Tests updated:
  - 2272 turnout baseline: `1159` → `1137`
  - `contacts_needed_estimate`: `5795` → `5685` (5 × 1137)
  - Multi-seat case (3 seats): `387` → `1137` (seats no longer divides)
  - Null-seats test repurposed to assert "does not depend on number_of_seats"

## Test plan

- [x] `npm test -- src/campaignStrategyContext`
- [ ] CI green
- [ ] Smoke-test against staging with a sample brHashId once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)