### PR TITLE
[DATA-1937] Correct District voter-stats column comment

### DIFF
--- a/prisma/schema/district.prisma
+++ b/prisma/schema/district.prisma
@@ -10,8 +10,11 @@ model District {
     // geographic identity columns above (District itself is L2-derived,
     // but these recompute every aggregation run).
     registeredVoters Int? @map("registered_voters")
-    // Distinct voters in this district whose L2 cellphone column is
-    // non-empty (uniqueness collapse is on lalvoterid, not phone number).
+    // Distinct cellphone numbers (votertelephones_cellphoneformatted)
+    // appearing on L2 voters in this district. Collapse is on the
+    // phone-number value itself, so two voters sharing a household
+    // phone count as one — matches per-channel send/dial costs
+    // downstream (SMS, robocall).
     uniqueCellphones Int? @map("unique_cellphones")
     // Same collapse semantics for the L2 landline column.
     uniqueLandlines  Int? @map("unique_landlines")


### PR DESCRIPTION
## Summary

Tiny comment-only fix on `prisma/schema/district.prisma`. PR #176 landed the `uniqueCellphones` / `uniqueLandlines` columns with a comment claiming the uniqueness collapse was on \`lalvoterid\` (distinct voters with a phone). The companion gp-data-platform change ([#421](https://github.com/thegoodparty/gp-data-platform/pull/421), commit \`ae217d1\`) inverted that semantic — the count is now distinct *phone numbers*, not distinct voters with phones — but the Prisma comment wasn't updated.

Column type and storage unchanged. Only the doc comment is corrected to match the actual aggregation now flowing into the column.

## Why phone-number collapse

A household landline shared by two voters costs one robocall, not two; same for an SMS to a shared cellphone. The aggregation downstream sizes voter-contact budgets, so the distinct-phone-number count is what consumers actually need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)