### PR TITLE
Add partisan_type to campaign-strategy-context.

### DIFF
--- a/src/campaignStrategyContext/campaign-strategy-context.schema.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.schema.ts
@@ -37,6 +37,7 @@ export type CampaignStrategyContextResponse = {
   number_of_seats: number | null
   office_level: string | null
   office_type: string | null
+  partisan_type: string | null
   official_office_name: string | null
   primary_election_date: string | null
   projected_turnout: number | null

--- a/src/campaignStrategyContext/campaign-strategy-context.service.test.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.service.test.ts
@@ -22,6 +22,7 @@ type RaceRow = {
   winNumber: number | null
   officeLevel: string | null
   officeType: string | null
+  partisanType: string | null
   officialOfficeName: string | null
   Candidacies: Array<{
     gpCandidateId: string | null
@@ -68,6 +69,7 @@ const baseRace = (overrides: Partial<RaceRow> = {}): RaceRow => ({
   winNumber: null,
   officeLevel: null,
   officeType: 'Other',
+  partisanType: 'nonpartisan',
   officialOfficeName: 'City Legislature',
   Candidacies: [
     {
@@ -170,6 +172,7 @@ describe('CampaignStrategyContextService', () => {
       number_of_seats: 1,
       office_level: null,
       office_type: 'Other',
+      partisan_type: 'nonpartisan',
       official_office_name: 'City Legislature',
       primary_election_date: null,
       projected_turnout: 2272,

--- a/src/campaignStrategyContext/campaign-strategy-context.service.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.service.ts
@@ -137,6 +137,7 @@ export class CampaignStrategyContextService extends createPrismaBase(MODELS.Race
       number_of_seats: race.numberOfSeats,
       office_level: race.officeLevel,
       office_type: race.officeType,
+      partisan_type: race.partisanType,
       official_office_name: race.officialOfficeName,
       primary_election_date: this.toIsoDate(primaryDate),
       projected_turnout: projectedTurnout,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive nullable response field with no auth or computation changes; consumers must tolerate the new key.
> 
> **Overview**
> The campaign strategy context API response now includes **`partisan_type`**, exposing the race’s partisan classification (e.g. `nonpartisan`) alongside existing office metadata.
> 
> The field is wired from **`Race.partisanType`** in **`CampaignStrategyContextService`**, added to **`CampaignStrategyContextResponse`**, and covered in the end-to-end service test fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b9ee3887d05e4b0980982fe8170efc313d26e3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->