### PR TITLE
ENG-7253 Position to zipcode endpoint.

### DIFF
--- a/src/zipToPosition/zipToPosition.controller.ts
+++ b/src/zipToPosition/zipToPosition.controller.ts
@@ -24,7 +24,7 @@ export class ZipToPositionController {
     })
   }
 
-  @Get(':brPositionId/zip-codes')
+  @Get('by-ballotready-id/:brPositionId/zip-codes')
   async getZipCodes(
     @Param() params: GetZipCodesByBrPositionIdParamsDTO,
   ): Promise<string[]> {

--- a/src/zipToPosition/zipToPosition.controller.ts
+++ b/src/zipToPosition/zipToPosition.controller.ts
@@ -1,5 +1,8 @@
 import { Controller, Get, Param, Query } from '@nestjs/common'
-import { SearchPositionsQueryDTO } from './zipToPosition.schema'
+import {
+  GetZipCodesByBrPositionIdParamsDTO,
+  SearchPositionsQueryDTO,
+} from './zipToPosition.schema'
 import { ZipToPositionService } from './zipToPosition.service'
 import { RaceListItem } from './zipToPosition.types'
 
@@ -23,8 +26,8 @@ export class ZipToPositionController {
 
   @Get(':brPositionId/zip-codes')
   async getZipCodes(
-    @Param('brPositionId') brPositionId: string,
+    @Param() params: GetZipCodesByBrPositionIdParamsDTO,
   ): Promise<string[]> {
-    return this.zipToPosition.getZipCodesByBrPositionId(brPositionId)
+    return this.zipToPosition.getZipCodesByBrPositionId(params.brPositionId)
   }
 }

--- a/src/zipToPosition/zipToPosition.controller.ts
+++ b/src/zipToPosition/zipToPosition.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common'
+import { Controller, Get, Param, Query } from '@nestjs/common'
 import { SearchPositionsQueryDTO } from './zipToPosition.schema'
 import { ZipToPositionService } from './zipToPosition.service'
 import { RaceListItem } from './zipToPosition.types'
@@ -19,5 +19,12 @@ export class ZipToPositionController {
       electionDateFrom: query.electionDateFrom,
       electionDateTo: query.electionDateTo,
     })
+  }
+
+  @Get(':brPositionId/zip-codes')
+  async getZipCodes(
+    @Param('brPositionId') brPositionId: string,
+  ): Promise<string[]> {
+    return this.zipToPosition.getZipCodesByBrPositionId(brPositionId)
   }
 }

--- a/src/zipToPosition/zipToPosition.schema.ts
+++ b/src/zipToPosition/zipToPosition.schema.ts
@@ -54,3 +54,11 @@ export const SearchPositionsQuerySchema = z
 export class SearchPositionsQueryDTO extends createZodDto(
   SearchPositionsQuerySchema,
 ) {}
+
+const getZipCodesByBrPositionIdParamsSchema = z.object({
+  brPositionId: z.string().min(1, 'brPositionId is required'),
+})
+
+export class GetZipCodesByBrPositionIdParamsDTO extends createZodDto(
+  getZipCodesByBrPositionIdParamsSchema,
+) {}

--- a/src/zipToPosition/zipToPosition.service.test.ts
+++ b/src/zipToPosition/zipToPosition.service.test.ts
@@ -156,6 +156,85 @@ describe('ZipToPositionService', () => {
   })
 })
 
+describe('ZipToPositionService.getZipCodesByBrPositionId', () => {
+  let service: ZipToPositionService
+  let findUnique: ReturnType<typeof vi.fn>
+  let findMany: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.setSystemTime(new Date('2026-05-12T12:00:00Z'))
+    findUnique = vi.fn()
+    findMany = vi.fn().mockResolvedValue([])
+    service = new ZipToPositionService()
+    Object.defineProperty(service, '_prisma', {
+      value: {
+        zipToPosition: { findMany },
+        position: { findUnique },
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('throws NotFoundException when no Position matches brPositionId', async () => {
+    findUnique.mockResolvedValue(null)
+
+    await expect(
+      service.getZipCodesByBrPositionId('br-missing'),
+    ).rejects.toThrowError(/Position br-missing not found/)
+    expect(findMany).not.toHaveBeenCalled()
+  })
+
+  it('queries ZipToPosition by positionId, future elections, threshold, non-null zip', async () => {
+    findUnique.mockResolvedValue({ id: 'position-uuid-1' })
+
+    await service.getZipCodesByBrPositionId('br-pos-1')
+
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { brPositionId: 'br-pos-1' },
+      select: { id: true },
+    })
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        positionId: 'position-uuid-1',
+        electionDate: { gte: new Date('2026-05-12T00:00:00Z') },
+        OR: [
+          { pctDistrictzipToZip: null },
+          { pctDistrictzipToZip: { gte: 0.005 } },
+        ],
+        zipCode: { not: null },
+      },
+      select: { zipCode: true },
+      distinct: ['zipCode'],
+    })
+  })
+
+  it('returns sorted zip codes and drops any null rows from results', async () => {
+    findUnique.mockResolvedValue({ id: 'position-uuid-1' })
+    findMany.mockResolvedValue([
+      { zipCode: '90212' },
+      { zipCode: null },
+      { zipCode: '90210' },
+      { zipCode: '90211' },
+    ])
+
+    const result = await service.getZipCodesByBrPositionId('br-pos-1')
+
+    expect(result).toEqual(['90210', '90211', '90212'])
+  })
+
+  it('returns an empty array when no rows match', async () => {
+    findUnique.mockResolvedValue({ id: 'position-uuid-1' })
+    findMany.mockResolvedValue([])
+
+    const result = await service.getZipCodesByBrPositionId('br-pos-1')
+
+    expect(result).toEqual([])
+  })
+})
+
 describe.skipIf(process.env.CI === 'true')(
   'ZipToPositionService (integration)',
   () => {

--- a/src/zipToPosition/zipToPosition.service.test.ts
+++ b/src/zipToPosition/zipToPosition.service.test.ts
@@ -162,6 +162,7 @@ describe('ZipToPositionService.getZipCodesByBrPositionId', () => {
   let findMany: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-12T12:00:00Z'))
     findUnique = vi.fn()
     findMany = vi.fn().mockResolvedValue([])

--- a/src/zipToPosition/zipToPosition.service.ts
+++ b/src/zipToPosition/zipToPosition.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { Injectable, NotFoundException } from '@nestjs/common'
 import { Prisma } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { RaceListItem } from './zipToPosition.types'
@@ -69,5 +69,37 @@ export class ZipToPositionService extends createPrismaBase(
       city: row.position.place?.name ?? null,
       district: row.district === '' ? null : row.district,
     }))
+  }
+
+  async getZipCodesByBrPositionId(brPositionId: string): Promise<string[]> {
+    const position = await this.client.position.findUnique({
+      where: { brPositionId },
+      select: { id: true },
+    })
+    if (!position) {
+      throw new NotFoundException(`Position ${brPositionId} not found`)
+    }
+
+    const today = new Date()
+    today.setUTCHours(0, 0, 0, 0)
+
+    const rows = await this.model.findMany({
+      where: {
+        positionId: position.id,
+        electionDate: { gte: today },
+        OR: [
+          { pctDistrictzipToZip: null },
+          { pctDistrictzipToZip: { gte: PCT_DISTRICTZIP_TO_ZIP_THRESHOLD } },
+        ],
+        zipCode: { not: null },
+      },
+      select: { zipCode: true },
+      distinct: ['zipCode'],
+    })
+
+    return rows
+      .map((r) => r.zipCode)
+      .filter((z): z is string => z !== null)
+      .sort()
   }
 }

--- a/src/zipToPosition/zipToPosition.service.ts
+++ b/src/zipToPosition/zipToPosition.service.ts
@@ -3,6 +3,9 @@ import { Prisma } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { RaceListItem } from './zipToPosition.types'
 
+// Use || (not ??) so empty, zero, or non-numeric env values all fall back
+// to the default. DATA-1896 (commit f9b49dc) made this choice explicit;
+// to disable the filter, set a tiny positive value, not 0.
 const PCT_DISTRICTZIP_TO_ZIP_THRESHOLD =
   Number(process.env.PCT_DISTRICTZIP_TO_ZIP_THRESHOLD) || 0.005
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Read-only election data lookup with shared filtering rules; no auth or mutation paths.
> 
> **Overview**
> Adds **`GET /v1/positions/:brPositionId/zip-codes`** so callers can list ZIPs associated with a BallotReady position (inverse of the existing ZIP → position search).
> 
> **`getZipCodesByBrPositionId`** resolves the internal `Position` by `brPositionId` and returns **404** if missing. It then reads distinct `ZipToPosition` rows for that position with **election date ≥ today (UTC midnight)**, the same **`pctDistrictzipToZip`** null-or-threshold filter as search, non-null ZIPs only, then returns a **sorted** string array.
> 
> Unit tests cover not-found behavior, query shape, sorting/null filtering, and empty results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f7c790331b83fd22c44a0f7bb1a35fc98513985. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->