### PR TITLE
QA <- Dev

### DIFF
--- a/prisma/migrations/20260528000000_add_district_voter_stat_columns/migration.sql
+++ b/prisma/migrations/20260528000000_add_district_voter_stat_columns/migration.sql
@@ -1,0 +1,12 @@
+-- Add L2-derived voter-aggregate columns directly to District (DATA-1937).
+--
+-- Three nullable Int columns at District grain. The dbt mart
+-- m_election_api__district will populate them on the next mart load
+-- after the corresponding mart changes ship. Kept nullable so a District
+-- without an L2 aggregation row (small set — turnout-only districts)
+-- doesn't block the upsert.
+
+ALTER TABLE "District"
+  ADD COLUMN "registered_voters" INTEGER,
+  ADD COLUMN "unique_cellphones" INTEGER,
+  ADD COLUMN "unique_landlines" INTEGER;

--- a/prisma/schema/district.prisma
+++ b/prisma/schema/district.prisma
@@ -6,6 +6,16 @@ model District {
     L2DistrictType String   @map("l2_district_type")
     L2DistrictName String   @map("l2_district_name")
 
+    // L2-derived voter aggregates. Refresh cadence differs from the
+    // geographic identity columns above (District itself is L2-derived,
+    // but these recompute every aggregation run).
+    registeredVoters Int? @map("registered_voters")
+    // Distinct voters in this district whose L2 cellphone column is
+    // non-empty (uniqueness collapse is on lalvoterid, not phone number).
+    uniqueCellphones Int? @map("unique_cellphones")
+    // Same collapse semantics for the L2 landline column.
+    uniqueLandlines  Int? @map("unique_landlines")
+
     // Relations
     ProjectedTurnouts ProjectedTurnout[]
     Positions         Position[]

--- a/prisma/schema/district.prisma
+++ b/prisma/schema/district.prisma
@@ -10,8 +10,11 @@ model District {
     // geographic identity columns above (District itself is L2-derived,
     // but these recompute every aggregation run).
     registeredVoters Int? @map("registered_voters")
-    // Distinct voters in this district whose L2 cellphone column is
-    // non-empty (uniqueness collapse is on lalvoterid, not phone number).
+    // Distinct cellphone numbers (votertelephones_cellphoneformatted)
+    // appearing on L2 voters in this district. Collapse is on the
+    // phone-number value itself, so two voters sharing a household
+    // phone count as one — matches per-channel send/dial costs
+    // downstream (SMS, robocall).
     uniqueCellphones Int? @map("unique_cellphones")
     // Same collapse semantics for the L2 landline column.
     uniqueLandlines  Int? @map("unique_landlines")

--- a/src/campaignStrategyContext/campaign-strategy-context.schema.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.schema.ts
@@ -40,6 +40,10 @@ export type CampaignStrategyContextResponse = {
   official_office_name: string | null
   primary_election_date: string | null
   projected_turnout: number | null
+  projected_voter_turnout: number | null
+  registered_voters: number | null
+  unique_cellphones: number | null
+  unique_landlines: number | null
   relevant_election_date: string | null
   state: string | null
   win_number_effective: number | null

--- a/src/campaignStrategyContext/campaign-strategy-context.schema.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.schema.ts
@@ -37,6 +37,7 @@ export type CampaignStrategyContextResponse = {
   number_of_seats: number | null
   office_level: string | null
   office_type: string | null
+  partisan_type: string | null
   official_office_name: string | null
   primary_election_date: string | null
   projected_turnout: number | null

--- a/src/campaignStrategyContext/campaign-strategy-context.service.test.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.service.test.ts
@@ -22,6 +22,7 @@ type RaceRow = {
   winNumber: number | null
   officeLevel: string | null
   officeType: string | null
+  partisanType: string | null
   officialOfficeName: string | null
   Candidacies: Array<{
     gpCandidateId: string | null
@@ -68,6 +69,7 @@ const baseRace = (overrides: Partial<RaceRow> = {}): RaceRow => ({
   winNumber: null,
   officeLevel: null,
   officeType: 'Other',
+  partisanType: 'nonpartisan',
   officialOfficeName: 'City Legislature',
   Candidacies: [
     {
@@ -170,6 +172,7 @@ describe('CampaignStrategyContextService', () => {
       number_of_seats: 1,
       office_level: null,
       office_type: 'Other',
+      partisan_type: 'nonpartisan',
       official_office_name: 'City Legislature',
       primary_election_date: null,
       projected_turnout: 2272,

--- a/src/campaignStrategyContext/campaign-strategy-context.service.test.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.service.test.ts
@@ -36,6 +36,9 @@ type RaceRow = {
     id: string
     district: {
       id: string
+      registeredVoters: number | null
+      uniqueCellphones: number | null
+      uniqueLandlines: number | null
       ProjectedTurnouts: Array<{
         electionYear: number
         electionCode: string
@@ -81,11 +84,19 @@ const baseRace = (overrides: Partial<RaceRow> = {}): RaceRow => ({
     id: 'pos-uuid-1',
     district: {
       id: 'dist-uuid-1',
+      registeredVoters: 18000,
+      uniqueCellphones: 12500,
+      uniqueLandlines: 5500,
       ProjectedTurnouts: [
         {
           electionYear: 2026,
           electionCode: ElectionCode.LocalOrMunicipal,
           projectedTurnout: 2272,
+        },
+        {
+          electionYear: 2026,
+          electionCode: ElectionCode.General,
+          projectedTurnout: 8400,
         },
       ],
     },
@@ -162,6 +173,10 @@ describe('CampaignStrategyContextService', () => {
       official_office_name: 'City Legislature',
       primary_election_date: null,
       projected_turnout: 2272,
+      projected_voter_turnout: 8400,
+      registered_voters: 18000,
+      unique_cellphones: 12500,
+      unique_landlines: 5500,
       relevant_election_date: '2026-08-25',
       state: 'AL',
       win_number_effective: 1137,
@@ -234,6 +249,286 @@ describe('CampaignStrategyContextService', () => {
     expect(result.contacts_needed_estimate).toBeNull()
   })
 
+  it('returns null voter-stats fields when the race has no position attached', async () => {
+    raceFindFirst.mockResolvedValue(baseRace({ Position: null }))
+
+    const result = await service.getCampaignStrategyContext(baseRequest())
+
+    expect(result.registered_voters).toBeNull()
+    expect(result.unique_cellphones).toBeNull()
+    expect(result.unique_landlines).toBeNull()
+    expect(result.projected_voter_turnout).toBeNull()
+  })
+
+  it('returns null voter-stats fields when the position has no district attached', async () => {
+    raceFindFirst.mockResolvedValue(
+      baseRace({ Position: { id: 'pos-uuid-1', district: null } }),
+    )
+
+    const result = await service.getCampaignStrategyContext(baseRequest())
+
+    expect(result.registered_voters).toBeNull()
+    expect(result.unique_cellphones).toBeNull()
+    expect(result.unique_landlines).toBeNull()
+    expect(result.projected_voter_turnout).toBeNull()
+  })
+
+  it('returns null voter-stats fields when the district has null aggregate columns', async () => {
+    // Districts that exist in the mart but have no L2 aggregation row
+    // (e.g. turnout-only synthetic districts) land in Postgres with the
+    // three count columns NULL. ProjectedTurnouts can still be populated
+    // for those rows and should flow through normally.
+    raceFindFirst.mockResolvedValue(
+      baseRace({
+        Position: {
+          id: 'pos-uuid-1',
+          district: {
+            id: 'dist-uuid-1',
+            registeredVoters: null,
+            uniqueCellphones: null,
+            uniqueLandlines: null,
+            ProjectedTurnouts: [
+              {
+                electionYear: 2026,
+                electionCode: ElectionCode.LocalOrMunicipal,
+                projectedTurnout: 2272,
+              },
+            ],
+          },
+        },
+      }),
+    )
+
+    const result = await service.getCampaignStrategyContext(baseRequest())
+
+    expect(result.registered_voters).toBeNull()
+    expect(result.unique_cellphones).toBeNull()
+    expect(result.unique_landlines).toBeNull()
+    // projected_turnout still comes through from ProjectedTurnouts
+    expect(result.projected_turnout).toBe(2272)
+  })
+
+  it('passes individual null voter-stats columns through as null', async () => {
+    raceFindFirst.mockResolvedValue(
+      baseRace({
+        Position: {
+          id: 'pos-uuid-1',
+          district: {
+            id: 'dist-uuid-1',
+            registeredVoters: 18000,
+            uniqueCellphones: null,
+            uniqueLandlines: null,
+            ProjectedTurnouts: [],
+          },
+        },
+      }),
+    )
+
+    const result = await service.getCampaignStrategyContext(baseRequest())
+
+    expect(result.registered_voters).toBe(18000)
+    expect(result.unique_cellphones).toBeNull()
+    expect(result.unique_landlines).toBeNull()
+  })
+
+  it('projected_voter_turnout is anchored to the General row for the race year regardless of race stage', async () => {
+    // Primary race in March; projected_turnout uses LocalOrMunicipal (via
+    // determineElectionCode), but projected_voter_turnout always picks
+    // the General row.
+    raceFindFirst.mockResolvedValue(
+      baseRace({
+        electionDate: new Date('2026-03-04T00:00:00Z'),
+        isPrimary: true,
+        Position: {
+          id: 'pos-uuid-1',
+          district: {
+            id: 'dist-uuid-1',
+            registeredVoters: null,
+            uniqueCellphones: null,
+            uniqueLandlines: null,
+            ProjectedTurnouts: [
+              {
+                electionYear: 2026,
+                electionCode: ElectionCode.LocalOrMunicipal,
+                projectedTurnout: 1500,
+              },
+              {
+                electionYear: 2026,
+                electionCode: ElectionCode.General,
+                projectedTurnout: 8400,
+              },
+            ],
+          },
+        },
+      }),
+    )
+
+    const result = await service.getCampaignStrategyContext(baseRequest())
+
+    expect(result.projected_voter_turnout).toBe(8400)
+  })
+
+  it('anchors projected_voter_turnout on the sibling General year for cross-year primary/general cycles', async () => {
+    // Louisiana-style Nov 2025 jungle primary feeding a Jan 2026 general.
+    // The Projected_Turnout row for the general lives at electionYear=2026,
+    // not 2025. The sibling-general date (filled by lookupSiblingStageDates)
+    // carries the correct year, so the resolver anchors on it instead of
+    // the looked-up race's own electionDate year.
+    raceFindFirst.mockResolvedValue(
+      baseRace({
+        electionDate: new Date('2025-11-08T00:00:00Z'),
+        isPrimary: true,
+        Position: {
+          id: 'pos-uuid-1',
+          district: {
+            id: 'dist-uuid-1',
+            registeredVoters: null,
+            uniqueCellphones: null,
+            uniqueLandlines: null,
+            ProjectedTurnouts: [
+              {
+                electionYear: 2026,
+                electionCode: ElectionCode.General,
+                projectedTurnout: 9000,
+              },
+            ],
+          },
+        },
+      }),
+    )
+    raceFindMany.mockResolvedValue([
+      {
+        electionDate: new Date('2026-01-15T00:00:00Z'),
+        isPrimary: false,
+        isRunoff: false,
+      },
+    ])
+
+    const result = await service.getCampaignStrategyContext(baseRequest())
+
+    expect(result.projected_voter_turnout).toBe(9000)
+    expect(result.primary_election_date).toBe('2025-11-08')
+    expect(result.general_election_date).toBe('2026-01-15')
+  })
+
+  it('returns null projected_voter_turnout when no General row exists for the race year', async () => {
+    raceFindFirst.mockResolvedValue(
+      baseRace({
+        Position: {
+          id: 'pos-uuid-1',
+          district: {
+            id: 'dist-uuid-1',
+            registeredVoters: null,
+            uniqueCellphones: null,
+            uniqueLandlines: null,
+            ProjectedTurnouts: [
+              {
+                electionYear: 2026,
+                electionCode: ElectionCode.LocalOrMunicipal,
+                projectedTurnout: 1500,
+              },
+            ],
+          },
+        },
+      }),
+    )
+
+    const result = await service.getCampaignStrategyContext(baseRequest())
+
+    expect(result.projected_voter_turnout).toBeNull()
+  })
+
+  it('returns null projected_voter_turnout when the only General row is from a different year', async () => {
+    raceFindFirst.mockResolvedValue(
+      baseRace({
+        electionDate: new Date('2026-08-25T00:00:00Z'),
+        Position: {
+          id: 'pos-uuid-1',
+          district: {
+            id: 'dist-uuid-1',
+            registeredVoters: null,
+            uniqueCellphones: null,
+            uniqueLandlines: null,
+            ProjectedTurnouts: [
+              {
+                electionYear: 2024,
+                electionCode: ElectionCode.General,
+                projectedTurnout: 9999,
+              },
+            ],
+          },
+        },
+      }),
+    )
+
+    const result = await service.getCampaignStrategyContext(baseRequest())
+
+    expect(result.projected_voter_turnout).toBeNull()
+  })
+
+  it('falls back to a ConsolidatedGeneral row when no General row exists for the year', async () => {
+    // LA / MS / NJ / VA odd-year generals and Kansas's quadrennial general
+    // are stored under ConsolidatedGeneral upstream. Without the fallback,
+    // projected_voter_turnout would silently be null for every race in
+    // those states.
+    raceFindFirst.mockResolvedValue(
+      baseRace({
+        Position: {
+          id: 'pos-uuid-1',
+          district: {
+            id: 'dist-uuid-1',
+            registeredVoters: null,
+            uniqueCellphones: null,
+            uniqueLandlines: null,
+            ProjectedTurnouts: [
+              {
+                electionYear: 2026,
+                electionCode: ElectionCode.ConsolidatedGeneral,
+                projectedTurnout: 7500,
+              },
+            ],
+          },
+        },
+      }),
+    )
+
+    const result = await service.getCampaignStrategyContext(baseRequest())
+
+    expect(result.projected_voter_turnout).toBe(7500)
+  })
+
+  it('prefers General over ConsolidatedGeneral when both exist for the same year', async () => {
+    raceFindFirst.mockResolvedValue(
+      baseRace({
+        Position: {
+          id: 'pos-uuid-1',
+          district: {
+            id: 'dist-uuid-1',
+            registeredVoters: null,
+            uniqueCellphones: null,
+            uniqueLandlines: null,
+            ProjectedTurnouts: [
+              {
+                electionYear: 2026,
+                electionCode: ElectionCode.ConsolidatedGeneral,
+                projectedTurnout: 7500,
+              },
+              {
+                electionYear: 2026,
+                electionCode: ElectionCode.General,
+                projectedTurnout: 8400,
+              },
+            ],
+          },
+        },
+      }),
+    )
+
+    const result = await service.getCampaignStrategyContext(baseRequest())
+
+    expect(result.projected_voter_turnout).toBe(8400)
+  })
+
   it('still computes win_number_effective from civics_win_number when projected_turnout is null', async () => {
     raceFindFirst.mockResolvedValue(
       baseRace({
@@ -287,6 +582,9 @@ describe('CampaignStrategyContextService', () => {
             id: 'pos-uuid-1',
             district: {
               id: 'dist-uuid-1',
+              registeredVoters: null,
+              uniqueCellphones: null,
+              uniqueLandlines: null,
               ProjectedTurnouts: [
                 {
                   electionYear: 2026,
@@ -315,6 +613,9 @@ describe('CampaignStrategyContextService', () => {
           id: 'pos-uuid-1',
           district: {
             id: 'dist-uuid-1',
+            registeredVoters: null,
+            uniqueCellphones: null,
+            uniqueLandlines: null,
             ProjectedTurnouts: [
               {
                 electionYear: 2024,
@@ -344,6 +645,9 @@ describe('CampaignStrategyContextService', () => {
           id: 'pos-uuid-1',
           district: {
             id: 'dist-uuid-1',
+            registeredVoters: null,
+            uniqueCellphones: null,
+            uniqueLandlines: null,
             ProjectedTurnouts: [
               {
                 electionYear: 2026,

--- a/src/campaignStrategyContext/campaign-strategy-context.service.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.service.ts
@@ -137,6 +137,7 @@ export class CampaignStrategyContextService extends createPrismaBase(MODELS.Race
       number_of_seats: race.numberOfSeats,
       office_level: race.officeLevel,
       office_type: race.officeType,
+      partisan_type: race.partisanType,
       official_office_name: race.officialOfficeName,
       primary_election_date: this.toIsoDate(primaryDate),
       projected_turnout: projectedTurnout,

--- a/src/campaignStrategyContext/campaign-strategy-context.service.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
+import { ElectionCode } from '@prisma/client'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { ProjectedTurnoutService } from 'src/projectedTurnout/projectedTurnout.service'
 import {
@@ -86,6 +87,21 @@ export class CampaignStrategyContextService extends createPrismaBase(MODELS.Race
       race.state,
     )
 
+    // Pass the *general*'s date (when known) so the resolver anchors on
+    // the General row's year, not the looked-up race's year. Matters for
+    // cross-year primary->general cycles (e.g. Louisiana Nov 2025 primary
+    // feeds a Jan 2026 general — the Projected_Turnout row is filed
+    // under year=2026). generalDate is already computed by
+    // lookupSiblingStageDates above: it's race.electionDate when the
+    // looked-up race IS the general, the sibling general's date when
+    // the looked-up race is a primary/runoff with a known sibling, or
+    // null when no sibling is found. The ?? fallback keeps behavior
+    // unchanged for the no-sibling case.
+    const projectedVoterTurnout = this.resolveGeneralProjectedTurnout(
+      race.Position?.district ?? null,
+      generalDate ?? race.electionDate,
+    )
+
     const winNumberEstimate = this.computeWinNumberEstimate(projectedTurnout)
     const winNumberEffective = race.winNumber ?? winNumberEstimate
     const contactsNeededEstimate =
@@ -106,6 +122,8 @@ export class CampaignStrategyContextService extends createPrismaBase(MODELS.Race
       }),
     )
 
+    const district = race.Position?.district ?? null
+
     return {
       candidate_count: candidates.length,
       candidate_office: this.composeCandidateOffice(
@@ -122,6 +140,10 @@ export class CampaignStrategyContextService extends createPrismaBase(MODELS.Race
       official_office_name: race.officialOfficeName,
       primary_election_date: this.toIsoDate(primaryDate),
       projected_turnout: projectedTurnout,
+      projected_voter_turnout: projectedVoterTurnout,
+      registered_voters: district?.registeredVoters ?? null,
+      unique_cellphones: district?.uniqueCellphones ?? null,
+      unique_landlines: district?.uniqueLandlines ?? null,
       relevant_election_date: this.toIsoDate(race.electionDate),
       state: race.state,
       win_number_effective: winNumberEffective,
@@ -226,6 +248,51 @@ export class CampaignStrategyContextService extends createPrismaBase(MODELS.Race
     const match = district.ProjectedTurnouts.find(
       (t) => t.electionYear === electionYear && t.electionCode === electionCode,
     )
+    return match?.projectedTurnout ?? null
+  }
+
+  // projected_voter_turnout is anchored to the General-election turnout for
+  // the race's calendar year, regardless of whether the looked-up race is a
+  // primary, general, or runoff. The campaign-plan template uses this as the
+  // single voter-turnout baseline that win-number and contact targets are
+  // sized against. Caller-provided include must order ProjectedTurnouts by
+  // inferenceAt desc so the latest model snapshot wins on .find().
+  //
+  // ConsolidatedGeneral is the upstream code for off-cycle general elections
+  // in LA / MS / NJ / VA (odd years) and Kansas's quadrennial general. The
+  // upstream Projected_Turnout table stores rows for those state/date combos
+  // under ConsolidatedGeneral, not General — fall through so the off-cycle
+  // states still resolve a turnout instead of silently returning null. When
+  // both codes exist for the same district+year (rare but possible),
+  // General wins.
+  private resolveGeneralProjectedTurnout(
+    district:
+      | {
+          ProjectedTurnouts: Array<{
+            electionYear: number
+            electionCode: string
+            projectedTurnout: number
+          }>
+        }
+      | null
+      | undefined,
+    electionDate: Date,
+  ): number | null {
+    if (!district?.ProjectedTurnouts?.length) {
+      return null
+    }
+    const electionYear = electionDate.getUTCFullYear()
+    const match =
+      district.ProjectedTurnouts.find(
+        (t) =>
+          t.electionYear === electionYear &&
+          t.electionCode === ElectionCode.General,
+      ) ??
+      district.ProjectedTurnouts.find(
+        (t) =>
+          t.electionYear === electionYear &&
+          t.electionCode === ElectionCode.ConsolidatedGeneral,
+      )
     return match?.projectedTurnout ?? null
   }
 


### PR DESCRIPTION
This PR releases election-api to QA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands a consumer-facing API contract and introduces turnout resolution rules (General vs ConsolidatedGeneral, cross-year dates); new District columns stay null until mart backfill.
> 
> **Overview**
> Adds **nullable L2 voter-aggregate columns** on `District` (`registered_voters`, `unique_cellphones`, `unique_landlines`) via migration and Prisma, intended to be filled by the dbt mart on the next load.
> 
> The **campaign strategy context** response grows with `partisan_type`, district-level voter/contact counts, and **`projected_voter_turnout`**: a general-election turnout baseline (distinct from stage-specific `projected_turnout`) resolved from `ProjectedTurnouts` for the general’s calendar year—using sibling general dates for cross-year primary→general cycles, with **`ConsolidatedGeneral`** fallback when `General` is absent. Missing position/district or null aggregates surface as null without breaking existing turnout/win-number behavior. Tests cover null paths, election-code precedence, and cross-year anchoring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63c517e38df09130291fd640547a18670467be41. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->