### PR TITLE
Fix misleading win_number field comment

### DIFF
--- a/prisma/schema/race.prisma
+++ b/prisma/schema/race.prisma
@@ -39,7 +39,7 @@ model Race {
   subAreaValue            String?       @map("sub_area_value")
   // Race-level civics attributes (DATA-1922)
   numberOfSeats           Int?          @map("number_of_seats")
-  winNumber               Int?          @map("win_number") // BallotReady viability_score.win_number; null for nearly all small non-partisan local races
+  winNumber               Int?          @map("win_number") // HubSpot-archive-sourced path-to-victory number (like officeLevel below). Only present for 2023-2025 archived races; BallotReady supplies no win number, so this is null for all current/upcoming races and services fall back to a computed estimate.
   isPartisan              Boolean?      @map("is_partisan")
   officeType              String?       @map("office_type")
   officialOfficeName      String?       @map("official_office_name")


### PR DESCRIPTION
## What

Corrects the inline comment on `Race.winNumber` in `prisma/schema/race.prisma`. Comment-only change, no schema/migration impact.

## Why

The prior comment read:

> `// BallotReady viability_score.win_number; null for nearly all small non-partisan local races`

Both claims are wrong, and they caused confusion on the team (whether `win_number_estimate` was redundant and could be removed, and whether the field was supposed to be null):

- BallotReady does **not** supply a win number. Verified against the warehouse: no BallotReady source (API race, S3 candidacies, viability_scores) carries a win number or viability win field.
- It is null for **100% of current/upcoming races**, not just small local ones. The only values that ever existed are HubSpot-archive rows for 2023-2025 elections (`int__civics_candidacy_2025`), which the race mart's forward-looking date filter excludes.

So `civics_win_number` is structurally null for everything this API serves, and `win_number_effective = race.winNumber ?? winNumberEstimate` always falls back to the computed estimate. The estimate must stay; it is the only live win number.

The new comment states the real source (HubSpot archive), the real coverage (2023-2025 only), and the fallback behavior.

A companion PR in `gp-data-platform` fixes the matching misleading comments in the dbt models and adds a guard test on the projected-turnout coverage that actually backs the estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)