### PR TITLE
Release prep: develop → qa (2026-06-02)

### DIFF
--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -9,6 +9,25 @@ const PRISMA_LOG_LEVELS = [
   ...(process.env.LOG_LEVEL === 'debug' ? ['query' as Prisma.LogLevel] : []),
 ]
 
+/**
+ * Builds a DATABASE_URL with connection pool parameters appended.
+ * Prisma uses `connection_limit` and `pool_timeout` as URL query params
+ * to control its internal connection pool.
+ *
+ * Defaults: connection_limit=10, pool_timeout=20 (seconds).
+ * Override via PRISMA_CONNECTION_LIMIT and PRISMA_POOL_TIMEOUT env vars.
+ */
+function buildDatabaseUrl(): string {
+  const baseUrl = process.env.DATABASE_URL || ''
+  const connectionLimit =
+    parseInt(process.env.PRISMA_CONNECTION_LIMIT || '', 10) || 10
+  const poolTimeout =
+    parseInt(process.env.PRISMA_POOL_TIMEOUT || '', 10) || 20
+
+  const separator = baseUrl.includes('?') ? '&' : '?'
+  return `${baseUrl}${separator}connection_limit=${connectionLimit}&pool_timeout=${poolTimeout}`
+}
+
 @Injectable()
 export class PrismaService
   extends PrismaClient<Prisma.PrismaClientOptions, 'query'>
@@ -16,6 +35,11 @@ export class PrismaService
 {
   constructor(private readonly logger: PinoLogger) {
     super({
+      datasources: {
+        db: {
+          url: buildDatabaseUrl(),
+        },
+      },
       log: PRISMA_LOG_LEVELS.map((level) => ({
         emit: 'event',
         level: level as Prisma.LogLevel,


### PR DESCRIPTION
## Included PRs

- 0cc12f1 Increase Prisma connection pool size to prevent pool exhaustion (#183)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every DB connection is pooled at startup; misconfigured limits or timeouts could worsen outages under load, though defaults and env overrides are straightforward.
> 
> **Overview**
> **Prisma** now connects using a constructed database URL that appends Prisma pool query parameters instead of passing `DATABASE_URL` through unchanged.
> 
> `PrismaService` adds `buildDatabaseUrl()`, which merges `connection_limit` (default **10**) and `pool_timeout` in seconds (default **20**) onto the existing URL, using `?` or `&` as appropriate. Operators can override via `PRISMA_CONNECTION_LIMIT` and `PRISMA_POOL_TIMEOUT`. The client is configured with `datasources.db.url` set to that built URL.
> 
> This targets connection pool exhaustion by making pool sizing explicit and tunable per environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cc12f1d80cceb5ddcaa46c04f55ccb3b3cc05f6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->