### PR TITLE
Release: qa → master (2026-06-02)

### DIFF
--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -9,6 +9,25 @@ const PRISMA_LOG_LEVELS = [
   ...(process.env.LOG_LEVEL === 'debug' ? ['query' as Prisma.LogLevel] : []),
 ]
 
+/**
+ * Builds a DATABASE_URL with connection pool parameters appended.
+ * Prisma uses `connection_limit` and `pool_timeout` as URL query params
+ * to control its internal connection pool.
+ *
+ * Defaults: connection_limit=10, pool_timeout=20 (seconds).
+ * Override via PRISMA_CONNECTION_LIMIT and PRISMA_POOL_TIMEOUT env vars.
+ */
+function buildDatabaseUrl(): string {
+  const baseUrl = process.env.DATABASE_URL || ''
+  const connectionLimit =
+    parseInt(process.env.PRISMA_CONNECTION_LIMIT || '', 10) || 10
+  const poolTimeout =
+    parseInt(process.env.PRISMA_POOL_TIMEOUT || '', 10) || 20
+
+  const separator = baseUrl.includes('?') ? '&' : '?'
+  return `${baseUrl}${separator}connection_limit=${connectionLimit}&pool_timeout=${poolTimeout}`
+}
+
 @Injectable()
 export class PrismaService
   extends PrismaClient<Prisma.PrismaClientOptions, 'query'>
@@ -16,6 +35,11 @@ export class PrismaService
 {
   constructor(private readonly logger: PinoLogger) {
     super({
+      datasources: {
+        db: {
+          url: buildDatabaseUrl(),
+        },
+      },
       log: PRISMA_LOG_LEVELS.map((level) => ({
         emit: 'event',
         level: level as Prisma.LogLevel,


### PR DESCRIPTION
## Included PRs (qa → master)

- 0cc12f1 Increase Prisma connection pool size to prevent pool exhaustion (#183)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every DB connection is opened; misconfigured limits or a malformed URL could cause outages or still exhaust the pool under load.
> 
> **Overview**
> **Prisma** now connects using a URL built at startup instead of the raw `DATABASE_URL` env value.
> 
> `buildDatabaseUrl()` appends Prisma pool query params: `connection_limit` (default **10**, `PRISMA_CONNECTION_LIMIT`) and `pool_timeout` in seconds (default **20**, `PRISMA_POOL_TIMEOUT`). Existing query strings get `&`; otherwise `?` is used.
> 
> `PrismaService` passes that URL via `datasources.db.url` in the client constructor to reduce connection pool exhaustion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9138a811196aad7531e1eaa3f5563c1822df2676. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->