### PR TITLE
chore(prisma): isolate client into per-package output dir (monorepo prep)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,9 @@ jobs:
           pulumi-version: "^3"
 
       - run: npm ci
+      # The Prisma client is generated to a gitignored custom output dir
+      # (src/generated/prisma); generate it explicitly before tests.
+      - run: npx prisma generate
       - run: npm run test
 
       - name: Build and push Docker image

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,5 +18,8 @@ jobs:
           cache: npm
 
       - run: npm ci
+      # The Prisma client is generated to a gitignored custom output dir
+      # (src/generated/prisma); generate it explicitly before type-check/tests.
+      - run: npx prisma generate
       - run: npx tsc --noEmit
       - run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 dist/
 api/dist
 
+# generated prisma client (per-package output dir)
+src/generated/
+
 # Node.js runtime environment
 node_modules
 nestjs/node_modules

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -74,10 +74,14 @@ COPY package.json package-lock.json ./
 RUN npm ci --only=production --ignore-scripts
 
 # Copy only necessary files to the runtime image
-COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/prisma ./prisma
 COPY module-alias.js ./
+# The Prisma client is generated to a custom output dir (src/generated/prisma)
+# which holds the client JS, its bundled runtime, and the query-engine binary.
+# `nest build` only transpiles .ts, so it is not emitted into dist; copy it to
+# the path the compiled code resolves at runtime (dist/src/generated/prisma).
+COPY --from=builder /app/src/generated/prisma ./dist/src/generated/prisma
 
 # Copy the entrypoint script and ensure it's executable
 COPY deploy/entrypoint.sh /app/entrypoint.sh

--- a/prisma/schema/schema.prisma
+++ b/prisma/schema/schema.prisma
@@ -2,6 +2,7 @@ generator client {
   provider        = "prisma-client-js"
   binaryTargets   = ["native", "linux-musl"]
   previewFeatures = ["prismaSchemaFolder"]
+  output          = "../../src/generated/prisma"
 }
 
 generator json {

--- a/src/campaignStrategyContext/campaign-strategy-context.service.test.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.service.test.ts
@@ -1,5 +1,5 @@
 import { NotFoundException } from '@nestjs/common'
-import { ElectionCode } from '@prisma/client'
+import { ElectionCode } from '../generated/prisma'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ProjectedTurnoutService } from 'src/projectedTurnout/projectedTurnout.service'
 import { CampaignStrategyContextService } from './campaign-strategy-context.service'

--- a/src/campaignStrategyContext/campaign-strategy-context.service.ts
+++ b/src/campaignStrategyContext/campaign-strategy-context.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
-import { ElectionCode } from '@prisma/client'
+import { ElectionCode } from '../generated/prisma'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { ProjectedTurnoutService } from 'src/projectedTurnout/projectedTurnout.service'
 import {

--- a/src/candidacies/candidacies.schema.ts
+++ b/src/candidacies/candidacies.schema.ts
@@ -2,7 +2,7 @@ import { createZodDto } from 'nestjs-zod'
 import { STATE_CODES } from 'src/shared/constants/states'
 import { toUpper } from 'src/shared/util/strings.util'
 import { z } from 'zod'
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../generated/prisma'
 
 export const candidacyColumns = Object.values(
   Prisma.CandidacyScalarFieldEnum,

--- a/src/candidacies/candidacies.service.ts
+++ b/src/candidacies/candidacies.service.ts
@@ -5,7 +5,7 @@ import {
   MODELS,
 } from 'src/prisma/util/prisma.util'
 import { CandidacyFilterDto } from './candidacies.schema'
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../generated/prisma'
 
 @Injectable()
 export class CandidaciesService extends createPrismaBase(MODELS.Candidacy) {

--- a/src/districts/districts.schema.ts
+++ b/src/districts/districts.schema.ts
@@ -1,4 +1,4 @@
-import { Prisma, ElectionCode as EC } from '@prisma/client'
+import { Prisma, ElectionCode as EC } from '../generated/prisma'
 import { createZodDto } from 'nestjs-zod'
 import { STATE_CODES } from 'src/shared/constants/states'
 import { z } from 'zod'

--- a/src/districts/districts.service.ts
+++ b/src/districts/districts.service.ts
@@ -8,7 +8,7 @@ import {
   GetDistrictsDTO,
   GetDistrictTypesDTO,
 } from './districts.schema'
-import { Prisma, ElectionCode as EC } from '@prisma/client'
+import { Prisma, ElectionCode as EC } from '../generated/prisma'
 import { NotFoundException } from '@nestjs/common'
 
 export class DistrictsService extends createPrismaBase(MODELS.District) {

--- a/src/places/place.types.ts
+++ b/src/places/place.types.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../generated/prisma'
 
 export const SLUG_COLUMN_NAME = 'slug'
 export const POSITION_NAMES_COLUMN_NAME = 'positionNames'

--- a/src/places/places.schema.ts
+++ b/src/places/places.schema.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../generated/prisma'
 import { createZodDto } from 'nestjs-zod'
 import { STATE_CODES } from 'src/shared/constants/states'
 import { z } from 'zod'

--- a/src/places/places.service.ts
+++ b/src/places/places.service.ts
@@ -5,7 +5,7 @@ import {
   MODELS,
 } from 'src/prisma/util/prisma.util'
 import { PlaceFilterDto } from './places.schema'
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../generated/prisma'
 import {
   hasChildren,
   hasParent,

--- a/src/positions/positions.service.test.ts
+++ b/src/positions/positions.service.test.ts
@@ -3,7 +3,7 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common'
-import { ElectionCode } from '@prisma/client'
+import { ElectionCode } from '../generated/prisma'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ProjectedTurnoutService } from 'src/projectedTurnout/projectedTurnout.service'
 import { PositionsService } from './positions.service'

--- a/src/positions/positions.service.ts
+++ b/src/positions/positions.service.ts
@@ -4,7 +4,7 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common'
-import { District, Position, Prisma, ProjectedTurnout } from '@prisma/client'
+import { District, Position, Prisma, ProjectedTurnout } from '../generated/prisma'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { ProjectedTurnoutService } from 'src/projectedTurnout/projectedTurnout.service'
 import { PositionWithOptionalDistrict } from './positions.types'

--- a/src/positions/positions.types.ts
+++ b/src/positions/positions.types.ts
@@ -1,4 +1,4 @@
-import { Position, ProjectedTurnout } from '@prisma/client'
+import { Position, ProjectedTurnout } from '../generated/prisma'
 import type { FilingFeeExtractionSource } from './util/filingFee.util'
 
 export type PositionWithOptionalDistrict = Pick<

--- a/src/positions/util/pickRelevantRace.util.ts
+++ b/src/positions/util/pickRelevantRace.util.ts
@@ -1,4 +1,4 @@
-import type { Race } from '@prisma/client'
+import type { Race } from '../../generated/prisma'
 
 /**
  * One BallotReady Position can correspond to many Race rows: separate primary

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
-import { Prisma, PrismaClient } from '@prisma/client'
+import { Prisma, PrismaClient } from '../generated/prisma'
 import { PinoLogger } from 'nestjs-pino'
 
 const PRISMA_LOG_LEVELS = [

--- a/src/prisma/util/prisma.util.ts
+++ b/src/prisma/util/prisma.util.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common'
 import { PrismaService } from '../prisma.service'
-import { Prisma, PrismaClient } from '@prisma/client'
+import { Prisma, PrismaClient } from '../../generated/prisma'
 import { lowerFirst } from 'lodash'
 
 export const MODELS = Prisma.ModelName

--- a/src/projectedTurnout/projectedTurnout.schema.ts
+++ b/src/projectedTurnout/projectedTurnout.schema.ts
@@ -1,6 +1,6 @@
 import { STATE_CODES } from 'src/shared/constants/states'
 import { z } from 'zod'
-import { ElectionCode } from '@prisma/client'
+import { ElectionCode } from '../generated/prisma'
 import { createZodDto } from 'nestjs-zod'
 
 const ElectionEnum = z.nativeEnum(ElectionCode)

--- a/src/projectedTurnout/projectedTurnout.service.ts
+++ b/src/projectedTurnout/projectedTurnout.service.ts
@@ -4,7 +4,7 @@ import {
   ProjectedTurnoutManyQueryDTO,
   ProjectedTurnoutUniqueDTO,
 } from './projectedTurnout.schema'
-import { ElectionCode } from '@prisma/client'
+import { ElectionCode } from '../generated/prisma'
 
 @Injectable()
 export class ProjectedTurnoutService extends createPrismaBase(

--- a/src/races/races.schema.ts
+++ b/src/races/races.schema.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../generated/prisma'
 import { createZodDto } from 'nestjs-zod'
 import { candidacyColumns } from 'src/candidacies/candidacies.schema'
 import { placeColumns } from 'src/places/places.schema'

--- a/src/races/races.service.ts
+++ b/src/races/races.service.ts
@@ -6,7 +6,7 @@ import {
 } from 'src/prisma/util/prisma.util'
 import { RaceFilterDto } from './races.schema'
 import { PrismaService } from 'src/prisma/prisma.service'
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../generated/prisma'
 import { getDedupedRacesBySlug } from './races.util'
 import {
   extractFilingFee,

--- a/src/zipToPosition/zipToPosition.service.ts
+++ b/src/zipToPosition/zipToPosition.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
-import { Prisma } from '@prisma/client'
+import { Prisma } from '../generated/prisma'
 import { createPrismaBase, MODELS } from 'src/prisma/util/prisma.util'
 import { RaceListItem } from './zipToPosition.types'
 


### PR DESCRIPTION
## Monorepo prep

Behavior-preserving upstream normalization ahead of the **omni** monorepo migration. The monorepo sync is additive/deterministic, so we fix upstream here first where CI validates in the real environment.

## What
- `prisma/schema/schema.prisma`: add `output = "../../src/generated/prisma"` to the `generator client` block (existing provider/binaryTargets/previewFeatures unchanged) so each package owns an isolated generated Prisma client.
- `.gitignore`: ignore `src/generated/`.
- Rewrote the bare `@prisma/client` import specifier to the relative generated path across **20 sites / 20 files** (validated codemod). `@prisma/client/...` subpath imports are intentionally left alone — they still resolve to the real npm package the generated client depends on.

## Validation
- `npx prisma generate` → confirmed output to `src/generated/prisma`.
- `npm run build` ✅ (zero Prisma-resolution errors).
- `npm test` → 116 passed, 1 skipped; the only failing suite is a DB integration test (`election_api_test` does not exist on localhost) — environment-only, unrelated to this change. Notably it resolves the new client from `src/generated/prisma/runtime/library.js`, confirming runtime resolution works.
- `src/generated/` confirmed git-ignored; not committed.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the Prisma client is built and shipped (CI, Docker, and all DB type imports); a missed `prisma generate` or wrong Docker copy would break builds or production DB access, though runtime behavior is intended to stay the same.
> 
> **Overview**
> Moves the Prisma client from the default **`@prisma/client`** package into a **gitignored per-package output** at **`src/generated/prisma`**, ahead of monorepo work so each package can own its own generated client.
> 
> **Schema & imports:** `generator client` now sets **`output = "../../src/generated/prisma"`**. Application code that imported **`Prisma`**, **`PrismaClient`**, and model enums from **`@prisma/client`** now uses relative paths like **`../generated/prisma`** (many modules under `src/`).
> 
> **Tooling:** **`.gitignore`** ignores **`src/generated/`**. **PR CI** runs **`npx prisma generate`** after **`npm ci`** and before **`tsc`** / tests so type-checking sees the generated client. **Docker** stops copying **`node_modules/.prisma`** and instead copies the built **`src/generated/prisma`** tree into **`dist/src/generated/prisma`** so compiled Nest code can load the client and query engine at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5ba99c44682cd8fe621633d1232cbc8de6f98de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->