### PR TITLE
chore(build): use swc builder for nest build (monorepo prep)

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -5,4 +5,4 @@ echo "Running database migrations..."
 npx prisma migrate deploy
 
 echo "Starting the application..."
-exec node -r ./dist/src/otel.js dist/src/main.js
+exec node -r ./dist/otel.js dist/main.js

--- a/module-alias.js
+++ b/module-alias.js
@@ -1,5 +1,5 @@
 const moduleAlias = require('module-alias')
 
 moduleAlias.addAliases({
-  'src': __dirname + '/dist/src'
+  'src': __dirname + '/dist'
 })

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,8 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
+    "builder": "swc",
+    "typeCheck": true,
     "deleteOutDir": true,
     "assets": ["prisma/**/*"],
     "watchAssets": true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node -r ./dist/src/otel.js dist/src/main.js",
+    "start:prod": "node -r ./dist/otel.js dist/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "lint-format": "npm run lint && npm run format",
     "migrate:dev": "npx prisma migrate dev",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import '../../module-alias'
+import '../module-alias'
 import './configrc'
 import { HttpAdapterHost, NestFactory } from '@nestjs/core'
 import {


### PR DESCRIPTION
## Monorepo prep

Behavior-preserving toolchain normalization ahead of the **omni** monorepo migration, converging election-api's Nest build with gp-api (which already builds with swc).

## What
- `nest-cli.json`: set `compilerOptions.builder` to `"swc"` with `"typeCheck": true` (mirrors gp-api). `unplugin-swc`/`@swc/core` are already devDeps (used by vitest), so no new dependencies and no `.swcrc` is needed — Nest's swc builder provides decorator metadata and DI resolves correctly.
- The swc builder emits a **flattened `dist/`** layout (`dist/main.js`) rather than tsc's `dist/src/` layout, so the layout-dependent runtime references are updated to match (the same layout gp-api already uses):
  - `src/main.ts`: `import '../module-alias'` (one level up from `dist/main.js`).
  - `module-alias.js`: alias `src` → `dist`.
  - `package.json` `start:prod` and `deploy/entrypoint.sh`: `dist/otel.js` + `dist/main.js`.

## Validation
- `npm run build` ✅ — `TSC Found 0 issues`, `swc` compiled 71 files.
- Boot test (`node -r ./dist/otel.js dist/main.js`): Nest bootstraps fully — `AppModule dependencies initialized`, PinoLogger + all DI resolve, `module-alias` resolves (stack frames show `dist/prisma/prisma.service.js`, `dist/main.js`). It only fails at `PrismaService.onModuleInit` with a DB auth error (P1000) using throwaway local credentials — environment-only, no swc/decorator/DI errors.
- `npm test` → 116 passed, 1 skipped; only the DB-integration suite fails (no DB) — environment-only, same as `develop`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production artifacts are laid out and started; a missed path would break deploy/boot, but the diff is narrowly scoped and consistent across entrypoints.
> 
> **Overview**
> Switches the Nest build to the **swc** builder (with `typeCheck: true`) instead of the default tsc output layout, aligning with gp-api ahead of monorepo work.
> 
> Because swc emits a **flat** `dist/` tree (`dist/main.js`, `dist/otel.js`) instead of `dist/src/…`, runtime entrypoints and path aliases are updated together: `start:prod`, `deploy/entrypoint.sh`, `module-alias` (`src` → `dist`), and `src/main.ts`’s `module-alias` import path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16497f290c0e4cc5da9d7be0457e176d1d0a7d09. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->