### PR TITLE
feat(races): surface filing office contact on by-br-hash-id endpoint (ENG-10325)

### DIFF
--- a/src/races/races.controller.ts
+++ b/src/races/races.controller.ts
@@ -1,7 +1,6 @@
 import { Controller, Get, Param, Query } from '@nestjs/common'
-import { RacesService } from './races.service'
+import { FilingDetailsByBrHashResult, RacesService } from './races.service'
 import { GetRaceByBrHashIdParamsDTO, RaceFilterDto } from './races.schema'
-import { FilingFeeResult } from 'src/positions/util/filingFee.util'
 
 @Controller('races')
 export class RacesController {
@@ -22,7 +21,7 @@ export class RacesController {
   @Get('by-br-hash-id/:brHashId/filing-fee')
   async getFilingFeeByBrHashId(
     @Param() params: GetRaceByBrHashIdParamsDTO,
-  ): Promise<FilingFeeResult> {
+  ): Promise<FilingDetailsByBrHashResult> {
     return this.racesService.findFilingFeeByBrHashId(params.brHashId)
   }
 }

--- a/src/races/races.service.test.ts
+++ b/src/races/races.service.test.ts
@@ -25,7 +25,13 @@ describe('RacesService.findFilingFeeByBrHashId', () => {
 
     expect(raceFindMany).toHaveBeenCalledWith({
       where: { brHashId: 'Z2lk-missing' },
-      select: { filingRequirements: true, salary: true },
+      select: {
+        filingRequirements: true,
+        salary: true,
+        filingOfficeAddress: true,
+        filingPhoneNumber: true,
+        paperworkInstructions: true,
+      },
       orderBy: [
         { isPrimary: { sort: 'asc', nulls: 'last' } },
         { isRunoff: { sort: 'asc', nulls: 'last' } },
@@ -36,6 +42,9 @@ describe('RacesService.findFilingFeeByBrHashId', () => {
       filingFee: null,
       filingRequirementsText: null,
       extractionSource: null,
+      filingOfficeAddress: null,
+      filingPhoneNumber: null,
+      paperworkInstructions: null,
     })
   })
 
@@ -155,5 +164,47 @@ describe('RacesService.findFilingFeeByBrHashId', () => {
     expect(result.filingRequirementsText).toBe(
       'Petition signatures required; see town clerk.',
     )
+  })
+
+  it('maps the structured filing-office contact off the matched Race row', async () => {
+    raceFindMany.mockResolvedValue([
+      {
+        filingRequirements: 'Filing fee: $30.',
+        salary: null,
+        filingOfficeAddress: '123 Main St, Springfield, IL 62701',
+        filingPhoneNumber: '(217) 555-0100',
+        paperworkInstructions: 'File with the county clerk in person.',
+      },
+    ])
+
+    const result = await service.findFilingFeeByBrHashId('Z2lk-office')
+
+    expect(result.filingOfficeAddress).toBe(
+      '123 Main St, Springfield, IL 62701',
+    )
+    expect(result.filingPhoneNumber).toBe('(217) 555-0100')
+    expect(result.paperworkInstructions).toBe(
+      'File with the county clerk in person.',
+    )
+    // Fee extraction still runs alongside the office mapping.
+    expect(result.filingFee).toBe(30)
+  })
+
+  it('returns null office fields when BallotReady left them blank', async () => {
+    raceFindMany.mockResolvedValue([
+      {
+        filingRequirements: 'Filing fee: $30.',
+        salary: null,
+        filingOfficeAddress: null,
+        filingPhoneNumber: null,
+        paperworkInstructions: null,
+      },
+    ])
+
+    const result = await service.findFilingFeeByBrHashId('Z2lk-no-office')
+
+    expect(result.filingOfficeAddress).toBeNull()
+    expect(result.filingPhoneNumber).toBeNull()
+    expect(result.paperworkInstructions).toBeNull()
   })
 })

--- a/src/races/races.service.ts
+++ b/src/races/races.service.ts
@@ -13,6 +13,19 @@ import {
   FilingFeeResult,
 } from 'src/positions/util/filingFee.util'
 
+/**
+ * Filing-fee result widened with the structured filing-office contact that
+ * gp-api surfaces on the Pro-upgrade filing-instructions screen. The three
+ * office fields come straight off the matched `Race` row (sourced from
+ * BallotReady); the fee fields come from `extractFilingFee`. All nullable —
+ * BallotReady leaves them blank for many races.
+ */
+export interface FilingDetailsByBrHashResult extends FilingFeeResult {
+  filingOfficeAddress: string | null
+  filingPhoneNumber: string | null
+  paperworkInstructions: string | null
+}
+
 @Injectable()
 export class RacesService extends createPrismaBase(MODELS.Race) {
   constructor(private readonly prisma: PrismaService) {
@@ -104,10 +117,18 @@ export class RacesService extends createPrismaBase(MODELS.Race) {
    * Returns all-nulls for both "no match" and "matched but BR has no fee" —
    * gp-api treats them identically.
    */
-  async findFilingFeeByBrHashId(brHashId: string): Promise<FilingFeeResult> {
+  async findFilingFeeByBrHashId(
+    brHashId: string,
+  ): Promise<FilingDetailsByBrHashResult> {
     const races = await this.model.findMany({
       where: { brHashId },
-      select: { filingRequirements: true, salary: true },
+      select: {
+        filingRequirements: true,
+        salary: true,
+        filingOfficeAddress: true,
+        filingPhoneNumber: true,
+        paperworkInstructions: true,
+      },
       // Postgres sorts NULLs before `false` in ASC order, so an imported
       // row with isPrimary=NULL would beat a real general (false). Force
       // NULLs last to keep the general → primary → runoff preference
@@ -124,9 +145,17 @@ export class RacesService extends createPrismaBase(MODELS.Race) {
         filingFee: null,
         filingRequirementsText: null,
         extractionSource: null,
+        filingOfficeAddress: null,
+        filingPhoneNumber: null,
+        paperworkInstructions: null,
       }
     }
-    return extractFilingFee(race.filingRequirements, race.salary)
+    return {
+      ...extractFilingFee(race.filingRequirements, race.salary),
+      filingOfficeAddress: race.filingOfficeAddress,
+      filingPhoneNumber: race.filingPhoneNumber,
+      paperworkInstructions: race.paperworkInstructions,
+    }
   }
 
   private buildPlaceInclude(


### PR DESCRIPTION
## What

Extends the `GET /races/by-br-hash-id/:brHashId/filing-fee` endpoint to also return the structured filing-office contact already stored on the `Race` model:

- `filingOfficeAddress`
- `filingPhoneNumber`
- `paperworkInstructions`

These columns are ingested from BallotReady but were never selected/returned. `findFilingFeeByBrHashId` now selects them and returns them on a widened `FilingDetailsByBrHashResult` alongside the existing extracted filing fee. All three are nullable (BR leaves them blank for many races).

## Why

Powers the "filing office" block on the gp-api Pro-upgrade filing-instructions screen (ENG-10325, task 04). The companion gp-api PR consumes these fields onto `RaceTargetMetrics`.

## Spike note

This confirmed BallotReady *does* expose structured filing-office contact (`Position.filingAddress` / `filingPhone` / `paperworkInstructions`), and election-api already persists it on `Race`. No new query path or vendor call — the data rides the existing race-hash lookup.

## Testing

`src/races/races.service.test.ts` — updated the select/empty-result assertions and added two tests (office fields mapped through when present; null when BR has none). 10/10 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API fields on an existing lookup route; fee extraction and race selection logic are unchanged aside from extra selected columns.
> 
> **Overview**
> Extends **`GET /races/by-br-hash-id/:brHashId/filing-fee`** so gp-api can show filing-office contact on the Pro-upgrade filing-instructions screen, without new BallotReady calls.
> 
> `findFilingFeeByBrHashId` now selects **`filingOfficeAddress`**, **`filingPhoneNumber`**, and **`paperworkInstructions`** from the same deterministically ordered `Race` row used for fee extraction, and returns them on a new **`FilingDetailsByBrHashResult`** (extends existing fee fields). No-match responses include those three fields as `null`. Controller return type updated accordingly.
> 
> Tests assert the widened Prisma `select`, empty-result shape, and pass-through vs null office fields while fee extraction behavior stays unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbfe8516ea2afed093601afbd3b4d033fff0c55a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->