### PR TITLE
fix(deploy): restore dist src runtime paths

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -80,7 +80,7 @@ COPY module-alias.js ./
 # The Prisma client is generated to a custom output dir (src/generated/prisma)
 # which holds the client JS, its bundled runtime, and the query-engine binary.
 # `nest build` only transpiles .ts, so it is not emitted into dist; copy it to
-# the path the compiled code resolves at runtime (dist/src/generated/prisma).
+# the path the compiled output resolves at runtime (dist/src/generated/prisma).
 COPY --from=builder /app/src/generated/prisma ./dist/src/generated/prisma
 
 # Copy the entrypoint script and ensure it's executable

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -5,4 +5,4 @@ echo "Running database migrations..."
 npx prisma migrate deploy
 
 echo "Starting the application..."
-exec node -r ./dist/otel.js dist/main.js
+exec node -r ./dist/src/otel.js dist/src/main.js

--- a/module-alias.js
+++ b/module-alias.js
@@ -1,5 +1,5 @@
 const moduleAlias = require('module-alias')
 
 moduleAlias.addAliases({
-  'src': __dirname + '/dist'
+  src: __dirname + '/dist/src',
 })

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node -r ./dist/otel.js dist/main.js",
+    "start:prod": "node -r ./dist/src/otel.js dist/src/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "lint-format": "npm run lint && npm run format",
     "migrate:dev": "npx prisma migrate dev",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import '../module-alias'
+import '../../module-alias'
 import './configrc'
 import { HttpAdapterHost, NestFactory } from '@nestjs/core'
 import {


### PR DESCRIPTION
## Summary
- Restore production start paths to the built `dist/src` layout (`dist/src/otel.js`, `dist/src/main.js`).
- Point the `src` module alias and bootstrap import back at `dist/src` so runtime absolute imports resolve.
- Keep the generated Prisma client copy aligned with the compiled `dist/src/generated/prisma` import path.

## Test plan
- `docker build -t election-api-dev-deploy-fix -f deploy/Dockerfile .`
- `docker run --rm --entrypoint node election-api-dev-deploy-fix -e "require('./module-alias'); require('src/prisma/prisma.service.js'); require('./dist/src/generated/prisma'); console.log('runtime-paths-ok')"`
- `docker run --rm --entrypoint node election-api-dev-deploy-fix -e "require.resolve('./dist/src/otel.js'); require.resolve('./dist/src/main.js'); console.log('entrypoint-files-ok')"`

## Root cause
The deploy image still builds into `dist/src`, but the SWC prep PR changed runtime references as if the image emitted a flat `dist` layout. ECS tasks could not start the app, so the service never became healthy and the deployment circuit breaker stopped the dev deploy.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production entrypoints and module resolution; wrong paths would prevent containers from starting, but the change realigns paths with the existing build layout.
> 
> **Overview**
> Restores production runtime paths so they match Nest’s **`dist/src`** build output instead of a flat **`dist`** layout that broke ECS deploys.
> 
> **`start:prod`**, **`deploy/entrypoint.sh`**, and **`module-alias.js`** now load **`./dist/src/otel.js`** and **`dist/src/main.js`**, and map the **`src`** alias to **`dist/src`** so absolute **`src/...`** imports resolve. **`src/main.ts`** again imports **`module-alias`** from the app root via **`../../module-alias`** (correct relative path from **`dist/src/main.js`**). The Dockerfile comment is updated to describe the **`dist/src/generated/prisma`** copy path; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 131cb25d3587b9525f5b09a4104b8c62f5f1ff33. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->